### PR TITLE
Use BN254Fr-native scalars in the prover hot path

### DIFF
--- a/GrothAlgebra/src/FiniteFields.jl
+++ b/GrothAlgebra/src/FiniteFields.jl
@@ -381,6 +381,9 @@ end
 canonical_bigint(x::T) where {T<:MontgomeryFiniteFieldElement} =
     limbs_to_bigint(montgomery_decode_limbs(T, montgomery_storage(x)))
 
+@inline canonical_limbs(x::T) where {T<:MontgomeryFiniteFieldElement} =
+    montgomery_decode_limbs(T, montgomery_storage(x))
+
 Base.iszero(x::T) where {T<:MontgomeryFiniteFieldElement} = montgomery_storage(x) == zero_limbs()
 Base.isone(x::T) where {T<:MontgomeryFiniteFieldElement} = montgomery_storage(x) == montgomery_one_limbs(T)
 

--- a/GrothAlgebra/src/Group.jl
+++ b/GrothAlgebra/src/Group.jl
@@ -280,6 +280,113 @@ function _multi_scalar_mul_pippenger(points::Vector{G}, scalars::Vector{S}, max_
     return result
 end
 
+function multi_scalar_mul(points::Vector{G}, scalars::Vector{BN254Fr}) where {C,G<:GroupElem{C}}
+    if length(points) != length(scalars)
+        throw(ArgumentError("Points and scalars must have the same length"))
+    end
+
+    isempty(points) && throw(ArgumentError("Cannot compute multi-scalar multiplication of empty vectors"))
+
+    if length(points) == 1
+        return scalar_mul(points[1], scalars[1])
+    end
+
+    scalar_limbs = Vector{NTuple{4,UInt64}}(undef, length(scalars))
+    max_bits = 0
+    @inbounds for i in eachindex(scalars)
+        limbs = canonical_limbs(scalars[i])
+        scalar_limbs[i] = limbs
+        max_bits = max(max_bits, _limbs_bit_length(limbs))
+    end
+
+    if max_bits == 0
+        return zero(points[1])
+    end
+
+    if length(points) < MSM_PIPPENGER_THRESHOLD
+        return _multi_scalar_mul_straus(points, scalar_limbs, max_bits)
+    end
+
+    return _multi_scalar_mul_pippenger(points, scalar_limbs, max_bits, _pippenger_window(G, length(points)))
+end
+
+function _multi_scalar_mul_straus(points::Vector{<:GroupElem{C}}, scalars::Vector{NTuple{4,UInt64}}, max_bits::Int) where C
+    if max_bits == 0
+        return zero(points[1])
+    end
+
+    result = zero(points[1])
+
+    for bit_pos in (max_bits - 1):-1:0
+        result = result + result
+
+        @inbounds for i in eachindex(points, scalars)
+            if _limbs_testbit(scalars[i], bit_pos)
+                result = result + points[i]
+            end
+        end
+    end
+
+    return result
+end
+
+function _multi_scalar_mul_pippenger(points::Vector{G}, scalars::Vector{NTuple{4,UInt64}}, max_bits::Int, window::Int) where {C,G<:GroupElem{C}}
+    normalized_points = Vector{G}(undef, length(points))
+    normalized_scalars = Vector{NTuple{4,UInt64}}(undef, length(scalars))
+    nonzero_count = 0
+
+    @inbounds for i in eachindex(points, scalars)
+        limbs = scalars[i]
+        _limbs_iszero(limbs) && continue
+        nonzero_count += 1
+        normalized_points[nonzero_count] = points[i]
+        normalized_scalars[nonzero_count] = limbs
+    end
+
+    if nonzero_count == 0
+        return zero(points[1])
+    elseif nonzero_count == 1
+        return scalar_mul(normalized_points[1], _bn254fr_from_canonical_limbs(normalized_scalars[1]))
+    elseif nonzero_count < MSM_PIPPENGER_THRESHOLD
+        resize!(normalized_points, nonzero_count)
+        resize!(normalized_scalars, nonzero_count)
+        return _multi_scalar_mul_straus(normalized_points, normalized_scalars, max_bits)
+    end
+
+    resize!(normalized_points, nonzero_count)
+    resize!(normalized_scalars, nonzero_count)
+
+    bucket_count = (1 << window) - 1
+    num_windows = cld(max_bits, window)
+    zero_point = zero(points[1])
+    buckets = fill(zero_point, bucket_count)
+    result = zero_point
+
+    for window_index in (num_windows - 1):-1:0
+        for _ in 1:window
+            result = result + result
+        end
+
+        fill!(buckets, zero_point)
+        shift = window_index * window
+
+        @inbounds for i in eachindex(normalized_points, normalized_scalars)
+            digit = _limbs_window_digit(normalized_scalars[i], shift, window)
+            if digit != 0
+                buckets[digit] = buckets[digit] + normalized_points[i]
+            end
+        end
+
+        running_sum = zero_point
+        @inbounds for bucket_index in bucket_count:-1:1
+            running_sum = running_sum + buckets[bucket_index]
+            result = result + running_sum
+        end
+    end
+
+    return result
+end
+
 @inline _pippenger_window(::Type{<:GroupElem}, size::Int) = _default_pippenger_window(size)
 
 @inline function _default_pippenger_window(size::Int)
@@ -296,6 +403,86 @@ end
     s == 0 && return 0
     return ndigits(abs(s), base=2)
 end
+
+@inline _limbs_iszero(limbs::NTuple{4,UInt64}) = limbs == zero_limbs()
+@inline _limbs_isone(limbs::NTuple{4,UInt64}) = limbs == (UInt64(1), UInt64(0), UInt64(0), UInt64(0))
+
+@inline function _limbs_bit_length(limbs::NTuple{4,UInt64})
+    @inbounds for i in MONT_LIMB_COUNT:-1:1
+        limb = limbs[i]
+        limb == 0 && continue
+        return (i - 1) * MONT_WORD_BITS + (MONT_WORD_BITS - leading_zeros(limb))
+    end
+    return 0
+end
+
+@inline _bit_length(s::BN254Fr) = _limbs_bit_length(canonical_limbs(s))
+
+@inline function _limbs_testbit(limbs::NTuple{4,UInt64}, bit::Int)
+    bit < 0 && return false
+    limb_index = (bit >>> 6) + 1
+    limb_index > MONT_LIMB_COUNT && return false
+    offset = bit & 63
+    return ((limbs[limb_index] >> offset) & UInt64(1)) == UInt64(1)
+end
+
+@inline function _limbs_window_digit(limbs::NTuple{4,UInt64}, shift::Int, width::Int)
+    digit = 0
+    @inbounds for bit_offset in 0:(width - 1)
+        bit = shift + bit_offset
+        limb_index = (bit >>> 6) + 1
+        limb_index > MONT_LIMB_COUNT && break
+        offset = bit & 63
+        digit |= Int((limbs[limb_index] >> offset) & UInt64(1)) << bit_offset
+    end
+    return digit
+end
+
+@inline function _limbs_sub_small(limbs::NTuple{4,UInt64}, small::UInt64)
+    out = MVector{4,UInt64}(undef)
+    @inbounds for i in 1:4
+        out[i] = limbs[i]
+    end
+    borrow = small
+    @inbounds for i in 1:MONT_LIMB_COUNT
+        borrow == 0 && break
+        prev = out[i]
+        out[i] = prev - borrow
+        borrow = prev < borrow ? UInt64(1) : UInt64(0)
+    end
+    borrow == 0 || throw(ArgumentError("underflow while subtracting small digit from scalar limbs"))
+    return (out[1], out[2], out[3], out[4])
+end
+
+@inline function _limbs_add_small(limbs::NTuple{4,UInt64}, small::UInt64)
+    out = MVector{4,UInt64}(undef)
+    @inbounds for i in 1:4
+        out[i] = limbs[i]
+    end
+    carry = small
+    @inbounds for i in 1:MONT_LIMB_COUNT
+        carry == 0 && break
+        prev = out[i]
+        out[i] = prev + carry
+        carry = out[i] < prev ? UInt64(1) : UInt64(0)
+    end
+    carry == 0 || throw(ArgumentError("overflow while adding small digit to scalar limbs"))
+    return (out[1], out[2], out[3], out[4])
+end
+
+@inline function _limbs_shift_right_one(limbs::NTuple{4,UInt64})
+    out = MVector{4,UInt64}(undef)
+    carry = UInt64(0)
+    @inbounds for i in MONT_LIMB_COUNT:-1:1
+        limb = limbs[i]
+        out[i] = (limb >> 1) | (carry << 63)
+        carry = limb & UInt64(1)
+    end
+    return (out[1], out[2], out[3], out[4])
+end
+
+@inline _bn254fr_from_canonical_limbs(limbs::NTuple{4,UInt64}) =
+    construct_montgomery(BN254Fr, montgomery_encode_limbs(BN254Fr, limbs))
 
 # w-NAF (windowed Non-Adjacent Form) utilities
 
@@ -344,6 +531,39 @@ function wnaf_encode(k::Integer, w::Int=4)
     return k >= 0 ? naf : -naf
 end
 
+function wnaf_encode(k::BN254Fr, w::Int=4)
+    if w < 2
+        throw(ArgumentError("Window size must be at least 2"))
+    end
+
+    limbs = canonical_limbs(k)
+    _limbs_iszero(limbs) && return [0]
+
+    naf = Int[]
+    width_mask = UInt64((1 << w) - 1)
+
+    while !_limbs_iszero(limbs)
+        if isodd(limbs[1])
+            digit = Int(limbs[1] & width_mask)
+            if digit >= (1 << (w - 1))
+                digit -= (1 << w)
+            end
+            push!(naf, digit)
+            if digit >= 0
+                limbs = _limbs_sub_small(limbs, UInt64(digit))
+            else
+                limbs = _limbs_add_small(limbs, UInt64(-digit))
+            end
+        else
+            push!(naf, 0)
+        end
+
+        limbs = _limbs_shift_right_one(limbs)
+    end
+
+    return naf
+end
+
 """
     scalar_mul_wnaf(P::GroupElem{C}, k::Integer, w::Int=4) where C
 
@@ -390,6 +610,65 @@ function scalar_mul_wnaf(P::GroupElem{C}, k::Integer, w::Int=4) where C
         end
     end
 
+    return result
+end
+
+function scalar_mul_wnaf(P::GroupElem{C}, k::BN254Fr, w::Int=4) where C
+    if iszero(k)
+        return zero(P)
+    elseif isone(k)
+        return P
+    end
+
+    max_odd = (1 << (w - 1)) - 1
+    precomputed = Vector{typeof(P)}(undef, max_odd)
+    precomputed[1] = P
+
+    if max_odd > 1
+        P2 = P + P
+        for i in 2:max_odd
+            precomputed[i] = precomputed[i - 1] + P2
+        end
+    end
+
+    naf = wnaf_encode(k, w)
+    result = zero(P)
+
+    for i in length(naf):-1:1
+        result = result + result
+
+        digit = naf[i]
+        if digit > 0
+            result = result + precomputed[div(digit + 1, 2)]
+        elseif digit < 0
+            result = result + (-precomputed[div(-digit + 1, 2)])
+        end
+    end
+
+    return result
+end
+
+function scalar_mul(P::GroupElem{C}, k::BN254Fr) where C
+    if iszero(k)
+        return zero(P)
+    elseif isone(k)
+        return P
+    end
+
+    bits = _bit_length(k)
+    w = _scalar_mul_window(typeof(P), bits)
+    if w > 0
+        return scalar_mul_wnaf(P, k, w)
+    end
+
+    limbs = canonical_limbs(k)
+    result = zero(P)
+    for bit_pos in (bits - 1):-1:0
+        result = result + result
+        if _limbs_testbit(limbs, bit_pos)
+            result = result + P
+        end
+    end
     return result
 end
 
@@ -456,12 +735,37 @@ function mul_fixed(table::FixedBaseTable{G}, k::Integer) where {G<:GroupElem}
     return acc
 end
 
+function mul_fixed(table::FixedBaseTable{G}, k::BN254Fr) where {G<:GroupElem}
+    if iszero(k)
+        return zero(table.precomp[1])
+    elseif isone(k)
+        return table.precomp[1]
+    end
+
+    naf = wnaf_encode(k, table.window)
+    acc = zero(table.precomp[1])
+    for i in length(naf):-1:1
+        acc = acc + acc
+        d = naf[i]
+        if d > 0
+            acc = acc + table.precomp[div(d + 1, 2)]
+        elseif d < 0
+            acc = acc + (-table.precomp[div(-d + 1, 2)])
+        end
+    end
+    return acc
+end
+
 """
     batch_mul(table::FixedBaseTable{G}, scalars::Vector{<:Integer}) where {G<:GroupElem}
 
 Compute `kᵢ · base` for each scalar in `scalars` via a shared fixed-base table.
 """
 function batch_mul(table::FixedBaseTable{G}, scalars::Vector{<:Integer}) where {G<:GroupElem}
+    return [mul_fixed(table, ki) for ki in scalars]
+end
+
+function batch_mul(table::FixedBaseTable{G}, scalars::Vector{BN254Fr}) where {G<:GroupElem}
     return [mul_fixed(table, ki) for ki in scalars]
 end
 

--- a/GrothAlgebra/test/test_groups.jl
+++ b/GrothAlgebra/test/test_groups.jl
@@ -85,6 +85,12 @@ using Test
         # Test operator overloads
         @test 3 * P == TestPoint(6, 9)
         @test P * 3 == TestPoint(6, 9)
+
+        # BN254Fr-native scalar path should match the integer path
+        @test scalar_mul(P, bn254_fr(0)) == O
+        @test scalar_mul(P, bn254_fr(1)) == P
+        @test scalar_mul(P, bn254_fr(5)) == scalar_mul(P, 5)
+        @test scalar_mul_wnaf(P, bn254_fr(23), 4) == scalar_mul(P, 23)
     end
     
     @testset "Multi-scalar Multiplication" begin
@@ -135,6 +141,10 @@ using Test
         big_points = [TestPointBig(BigInt(i), BigInt(2i)) for i in 1:12]
         big_scalars = [BigInt((-1)^i) * (BigInt(1) << (50 + i)) for i in 1:12]
         @test multi_scalar_mul(big_points, big_scalars) == naive_msm(big_points, big_scalars)
+
+        fr_points = [TestPoint(i, 2i) for i in 1:12]
+        fr_scalars = [bn254_fr(7 * i + 3) for i in 1:12]
+        @test multi_scalar_mul(fr_points, fr_scalars) == naive_msm(fr_points, map(x -> Int(convert(BigInt, x)), fr_scalars))
     end
 
     @testset "Forced Pippenger windows preserve MSM semantics" begin
@@ -175,6 +185,16 @@ using Test
         
         # Test invalid window size
         @test_throws ArgumentError wnaf_encode(5, 1)
+
+        fr_scalar = bn254_fr(29)
+        @test wnaf_encode(fr_scalar, 4) == wnaf_encode(29, 4)
+    end
+
+    @testset "Fixed-base BN254Fr scalars" begin
+        P = TestPoint(2, 3)
+        table = build_fixed_table(P; window=4)
+        scalars = [bn254_fr(0), bn254_fr(1), bn254_fr(5), bn254_fr(17)]
+        @test batch_mul(table, scalars) == [scalar_mul(P, 0), scalar_mul(P, 1), scalar_mul(P, 5), scalar_mul(P, 17)]
     end
     
     @testset "w-NAF Scalar Multiplication" begin

--- a/GrothCurves/src/BN254Curve.jl
+++ b/GrothCurves/src/BN254Curve.jl
@@ -190,6 +190,20 @@ function glv_scalar_mul(p::P, k::Integer) where {P<:ProjectivePoint{BN254Curve}}
     return _glv_joint_scalar_mul(p, coeffs, glv_endomorphism(p))
 end
 
+@inline _bn254fr_scalar_bigint(k::GrothAlgebra.BN254Fr) =
+    GrothAlgebra.limbs_to_bigint(GrothAlgebra.canonical_limbs(k))
+
+function glv_scalar_mul(p::P, k::GrothAlgebra.BN254Fr) where {P<:ProjectivePoint{BN254Curve}}
+    if iszero(k)
+        return zero(p)
+    elseif isone(k)
+        return p
+    end
+
+    coeffs = glv_scalar_decomposition(P, _bn254fr_scalar_bigint(k))
+    return _glv_joint_scalar_mul(p, coeffs, glv_endomorphism(p))
+end
+
 function GrothAlgebra.scalar_mul(p::G1Point, k::Integer)
     if k == 0
         return zero(p)
@@ -197,6 +211,21 @@ function GrothAlgebra.scalar_mul(p::G1Point, k::Integer)
         return p
     elseif k == -1
         return -p
+    end
+
+    bits = GrothAlgebra._bit_length(k)
+    if bits < BN254_G1_GLV_THRESHOLD_BITS
+        return GrothAlgebra.scalar_mul_wnaf(p, k, _scalar_mul_window(G1Point, bits))
+    end
+
+    return glv_scalar_mul(p, k)
+end
+
+function GrothAlgebra.scalar_mul(p::G1Point, k::GrothAlgebra.BN254Fr)
+    if iszero(k)
+        return zero(p)
+    elseif isone(k)
+        return p
     end
 
     bits = GrothAlgebra._bit_length(k)

--- a/GrothCurves/test/test_bn254_curve.jl
+++ b/GrothCurves/test/test_bn254_curve.jl
@@ -368,6 +368,31 @@ glv_component_bits(component::Tuple{Bool,BigInt}) = iszero(component[2]) ? 0 : n
                 @test scalar_mul(g2, scalar) == scalar_mul_reference(g2, scalar)
             end
         end
+
+        @testset "BN254Fr-native scalar paths match integer reference paths" begin
+            g1 = g1_generator()
+            g2 = g2_generator()
+            fr_scalars = [
+                bn254_fr(1),
+                bn254_fr(23),
+                bn254_fr(benchmark_scalar(601)),
+                bn254_fr(GrothCurves.BN254_ORDER_R - 1234567),
+            ]
+
+            for scalar in fr_scalars
+                scalar_big = convert(BigInt, scalar)
+                @test scalar_mul(g1, scalar) == scalar_mul_reference(g1, scalar_big)
+                @test scalar_mul(g2, scalar) == scalar_mul_reference(g2, scalar_big)
+            end
+
+            g1_points = [scalar_mul(g1, 3), scalar_mul(g1, 5), scalar_mul(g1, 7)]
+            g2_points = [scalar_mul(g2, 11), scalar_mul(g2, 13), scalar_mul(g2, 17)]
+            msm_scalars = [bn254_fr(19), bn254_fr(29), bn254_fr(31)]
+            msm_bigints = map(x -> convert(BigInt, x), msm_scalars)
+
+            @test multi_scalar_mul(g1_points, msm_scalars) == multi_scalar_mul(g1_points, msm_bigints)
+            @test multi_scalar_mul(g2_points, msm_scalars) == multi_scalar_mul(g2_points, msm_bigints)
+        end
     end
     
     @testset "Fp2 Field Operations" begin

--- a/GrothProofs/src/Groth16.jl
+++ b/GrothProofs/src/Groth16.jl
@@ -12,13 +12,6 @@ using Random
 
 # R1CS and QAP are included at the package level (GrothProofs.jl)
 
-"""
-    _to_int(x)
-
-Convert a field element to an `Integer` scalar for use with `scalar_mul`.
-"""
-_to_int(x) = convert(BigInt, x)
-
 @inline function _rand_field(::Type{F}, rng::AbstractRNG) where F
     F === BN254Fr || throw(ArgumentError("No CSPRNG-ready sampler configured for field $F"))
     return F(rand(rng, 0:GrothCurves.BN254_ORDER_R-1))
@@ -142,10 +135,10 @@ function setup_full(qap::QAP{F}; rng::AbstractRNG=Random.GLOBAL_RNG, engine::Abs
     g2tab = GrothAlgebra.build_fixed_table(g2)
 
     # Map evaluations into group queries using fixed-base batch mul
-    A_query_g1 = GrothAlgebra.batch_mul(g1tab, [_to_int(A_eval[i]) for i in 1:m])
-    B_query_g2 = GrothAlgebra.batch_mul(g2tab, [_to_int(B_eval[i]) for i in 1:m])
-    B_query_g1 = GrothAlgebra.batch_mul(g1tab, [_to_int(B_eval[i]) for i in 1:m])
-    C_query_g1 = GrothAlgebra.batch_mul(g1tab, [_to_int(C_eval[i]) for i in 1:m])
+    A_query_g1 = GrothAlgebra.batch_mul(g1tab, A_eval)
+    B_query_g2 = GrothAlgebra.batch_mul(g2tab, B_eval)
+    B_query_g1 = GrothAlgebra.batch_mul(g1tab, B_eval)
+    C_query_g1 = GrothAlgebra.batch_mul(g1tab, C_eval)
 
     # Target polynomial at τ
     t_tau = evaluate(qap.t, τ)
@@ -160,23 +153,23 @@ function setup_full(qap::QAP{F}; rng::AbstractRNG=Random.GLOBAL_RNG, engine::Abs
     end
 
     # H_query_g1: [τ^k · t(τ) / δ]₁
-    H_query_g1 = GrothAlgebra.batch_mul(g1tab, [_to_int(t_tau * tau_powers[k] * δ_inv) for k in 1:max_k])
+    H_query_g1 = GrothAlgebra.batch_mul(g1tab, [t_tau * tau_powers[k] * δ_inv for k in 1:max_k])
 
     # L_query for private variables only: [(β·u_i(τ) + α·v_i(τ) + w_i(τ)) / δ]₁
     num_public = qap.num_public
     L_query_g1 = G1Point[]
     if m > num_public
-        L_scalars = BigInt[]
+        L_scalars = F[]
         sizehint!(L_scalars, m - num_public)
         for i in (num_public+1):m
             acc = β * A_eval[i] + α * B_eval[i] + C_eval[i]
-            push!(L_scalars, _to_int(acc * δ_inv))
+            push!(L_scalars, acc * δ_inv)
         end
         L_query_g1 = GrothAlgebra.batch_mul(g1tab, L_scalars)
     end
 
     # IC for public inputs: [(β·u_i(τ) + α·v_i(τ) + w_i(τ)) / γ]₁, including 1
-    IC_scalars = [_to_int((β * A_eval[i] + α * B_eval[i] + C_eval[i]) * γ_inv) for i in 1:num_public]
+    IC_scalars = [(β * A_eval[i] + α * B_eval[i] + C_eval[i]) * γ_inv for i in 1:num_public]
     IC = GrothAlgebra.batch_mul(g1tab, IC_scalars)
 
     # Normalize queries to affine for efficient storage
@@ -189,12 +182,12 @@ function setup_full(qap::QAP{F}; rng::AbstractRNG=Random.GLOBAL_RNG, engine::Abs
     GrothCurves.batch_to_affine!(B_query_g2)
 
     # Fixed elements
-    alpha_g1 = scalar_mul(g1, _to_int(α))
-    beta_g1 = scalar_mul(g1, _to_int(β))
-    beta_g2 = scalar_mul(g2, _to_int(β))
-    gamma_g2 = scalar_mul(g2, _to_int(γ))
-    delta_g1 = scalar_mul(g1, _to_int(δ))
-    delta_g2 = scalar_mul(g2, _to_int(δ))
+    alpha_g1 = scalar_mul(g1, α)
+    beta_g1 = scalar_mul(g1, β)
+    beta_g2 = scalar_mul(g2, β)
+    gamma_g2 = scalar_mul(g2, γ)
+    delta_g1 = scalar_mul(g1, δ)
+    delta_g2 = scalar_mul(g2, δ)
 
     pk = ProvingKey(
         alpha_g1,
@@ -241,7 +234,7 @@ function prove_full(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng::Abstr
     s = debug_no_random ? zero(F) : _rand_field(F, rng)
 
     # Accumulators for queries via MSM (fallbacks to scalar loops for tiny sizes)
-    scalars = [_to_int(w_vals[i]) for i in 1:m]
+    scalars = w_vals[1:m]
     A_acc_g1 = GrothAlgebra.multi_scalar_mul(pk.A_query_g1, scalars)
     B_acc_g2 = GrothAlgebra.multi_scalar_mul(pk.B_query_g2, scalars)
     B_acc_g1 = GrothAlgebra.multi_scalar_mul(pk.B_query_g1, scalars)
@@ -249,20 +242,20 @@ function prove_full(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng::Abstr
     # A and B
     A1_g1 = pk.alpha_g1 + A_acc_g1
     B1_g1 = pk.beta_g1 + B_acc_g1
-    A = A1_g1 + scalar_mul(pk.delta_g1, _to_int(r))
-    B = pk.beta_g2 + B_acc_g2 + scalar_mul(pk.delta_g2, _to_int(s))
+    A = A1_g1 + scalar_mul(pk.delta_g1, r)
+    B = pk.beta_g2 + B_acc_g2 + scalar_mul(pk.delta_g2, s)
 
     # h(x): compute via coset FFT path and map coefficients via H_query
     h_poly = compute_h_polynomial(qap, witness)
     hk = length(h_poly.coeffs)
     pts_h = pk.H_query_g1[1:hk]
-    scalars_h = [_to_int(c) for c in h_poly.coeffs]
+    scalars_h = h_poly.coeffs
     H = GrothAlgebra.multi_scalar_mul(pts_h, scalars_h)
 
     # L for private variables
     # L for private variables via MSM
     if m > pk.num_public
-        priv_scalars = [_to_int(w_vals[i]) for i in (pk.num_public+1):m]
+        priv_scalars = w_vals[(pk.num_public+1):m]
         L = GrothAlgebra.multi_scalar_mul(pk.L_query_g1, priv_scalars)
     else
         L = zero(G1Point)
@@ -270,9 +263,9 @@ function prove_full(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng::Abstr
 
     # Cross terms in C (arkworks style): C = s*g_a + r*g1_b - r*s*δ + L + H
     # where g_a = A (includes r*δ), and g1_b = (β + Σ v_i) + s*δ in G1
-    rs_delta = scalar_mul(pk.delta_g1, _to_int(r * s))
-    g1_b_full = B1_g1 + scalar_mul(pk.delta_g1, _to_int(s))
-    C = H + L + scalar_mul(g1_b_full, _to_int(r)) + scalar_mul(A, _to_int(s)) - rs_delta
+    rs_delta = scalar_mul(pk.delta_g1, r * s)
+    g1_b_full = B1_g1 + scalar_mul(pk.delta_g1, s)
+    C = H + L + scalar_mul(g1_b_full, r) + scalar_mul(A, s) - rs_delta
 
     return Groth16Proof(A, B, C)
 end
@@ -309,7 +302,7 @@ function verify_full(vk::VerificationKey{E}, proof::Groth16Proof, public_inputs:
     vk_x = vk.IC[1]
     if expected_len > 0
         pts_ic = vk.IC[2:end]
-        scal_ic = [_to_int(public_inputs[i]) for i in 1:expected_len]
+        scal_ic = public_inputs
         vk_x += GrothAlgebra.multi_scalar_mul(pts_ic, scal_ic)
     end
 
@@ -370,7 +363,7 @@ function prepare_inputs(pvk::PreparedVerificationKey{E}, public_inputs::Vector{F
     for i in 1:expected_len
         xi = public_inputs[i]
         iszero(xi) && continue
-        acc += scalar_mul(vk.IC[i+1], _to_int(xi))
+        acc += scalar_mul(vk.IC[i+1], xi)
     end
     return acc
 end

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,13 +58,16 @@ Completed stages:
 - Stage 6: pairing engine migration
 - Stage 7: MSM and scalar-mul specialization
 - Stage 7A: BN254 GLV scalar multiplication
+- Stage 8: `prove_full` integration and regression baseline
+- Stage 8A: BN254Fr-native prover scalar plumbing
 
 Next concrete work:
 
-- finish Stage 8 follow-through on the end-to-end `prove_full` baseline
-- then target the remaining prover bottlenecks revealed by that baseline,
-  starting from the MSM-heavy buckets rather than assuming the next win is in
-  final proof assembly
+- target the remaining measured `BigInt` / GMP work that still appears after
+  Stage 8A, starting with limb-native inversion and final-exponentiation
+  specialization
+- then re-evaluate the next highest-value prover bottleneck from the updated
+  `prove_full` profile instead of assuming the next win is only in MSM
 
 Stage 8 remains the end-to-end `prove_full` integration and regression
 baseline stage.
@@ -547,6 +550,49 @@ Notes:
 - The Stage 8 baseline therefore updated the hotspot ranking successfully, but
   it did not yet satisfy the “total `prove_full` time drops materially” exit
   criterion on the primary larger fixture.
+
+### Stage 8A Follow-Through: BN254Fr-Native Prover Scalar Plumbing
+
+Goal:
+Eliminate the `BN254Fr -> BigInt` scalar bounce from the prover and setup hot
+paths, then measure whether that plumbing change moves the real `prove_full`
+baseline.
+
+Status:
+Completed on 2026-04-02.
+
+Deliverables:
+
+- direct `BN254Fr` scalar support in `scalar_mul`, `multi_scalar_mul`, and
+  fixed-base batch multiplication
+- prover/setup/benchmark wiring that uses `BN254Fr` scalars directly instead of
+  converting through `BigInt`
+- a dedicated scalar-plumbing benchmark comparing `BigInt` and native
+  `BN254Fr` prover workloads
+- a refreshed `prove_full` baseline and profile tied to the new scalar path
+
+Notes:
+
+- The dedicated scalar-plumbing comparison lives in
+  `benchmarks/artifacts/2026-04-01_223814`.
+- The full Stage 8A re-baseline artifact is
+  `benchmarks/artifacts/2026-04-01_223859`.
+- Relative to the first Stage 8 baseline
+  (`benchmarks/artifacts/2026-04-01_220953`):
+  - `generated_24_constraints` `prove_full` improved from `30.088 ms` to
+    `28.873 ms` (`-4.0%`)
+  - `msm_b_g2` improved from `4.714 ms` to `4.334 ms` (`-8.1%`)
+  - `h_msm` improved from `7.805 ms` to `7.036 ms` (`-9.9%`)
+  - `l_msm` improved from `4.210 ms` to `3.856 ms` (`-8.4%`)
+  - `final_c` improved from `3.001 ms` to `2.804 ms` (`-6.6%`)
+  - the tiny continuity fixture regressed slightly (`8.248 ms -> 8.614 ms`),
+    which is acceptable because the larger deterministic fixture is the primary
+    optimization target
+- The Stage 8A `prove_full` profile no longer contains `canonical_bigint` or
+  `limbs_to_bigint` in the main `generated_24_constraints` prover dump, which
+  confirms that the hot prover scalar conversions were removed successfully.
+- `BigInt` / GMP activity still exists elsewhere in the backend, so the scalar
+  plumbing win is not the end of the gap-to-arkworks story.
 
 ## Stage 9: Parallelism, SIMD, And Optional Accelerators
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -45,6 +45,10 @@ This directory contains a self-contained BenchmarkTools environment and four scr
   - larger deterministic fixture: `generated_24_constraints`
   - end-to-end prove time plus subphases for witness scalar conversion, query MSMs,
     `compute_h_polynomial`, `H` MSM, `L` MSM, and final `C` assembly
+- Stage 8A prover scalar plumbing comparison
+  - direct `BigInt` vs native `BN254Fr` comparisons for prover-like scalar
+    multiplication and MSM workloads on the deterministic `generated_24_constraints`
+    fixture
 
 Microbenchmarks run at sizes N ∈ {32, 128, 512}. Results are printed with min/median/mean and memory, and artifacts are saved under:
 
@@ -64,7 +68,7 @@ Each JSON entry records:
 
 `plot.jl` produces the following visual comparisons (all using median timings):
 
-- Primitive baselines: `bn254_fq_ops.png`, `bn254_fr_ops.png`, `bn254_polynomials.png`, `bn254_fp2_ops.png`, `bn254_fp6_ops.png`, `bn254_fp12_ops.png`, `bn254_scalar_mul.png`, `bn254_glv_scalar_g1.png`, `bn254_glv_scalar_g2.png`, `bn254_curve_kernels.png`
+- Primitive baselines: `bn254_fq_ops.png`, `bn254_fr_ops.png`, `bn254_polynomials.png`, `bn254_fp2_ops.png`, `bn254_fp6_ops.png`, `bn254_fp12_ops.png`, `bn254_scalar_mul.png`, `bn254_glv_scalar_g1.png`, `bn254_glv_scalar_g2.png`, `bn254_curve_kernels.png`, `scalar_plumbing.png`
 - Microbenchmarks: `fixed_g1.png`, `fixed_g2.png`, `msm_g1.png`, `msm_g2.png`, `norm_g1.png`, `norm_g2.png`
 - External primitive comparison: `py_ecc_scalar.png`, `py_ecc_naive_accum_g1.png`, `py_ecc_naive_accum_g2.png`, `py_ecc_pairing.png`
 - Pairing comparisons: `pairing.png` (sequential vs batch), `pairing_ops.png` (miller loop / final exponent)
@@ -207,6 +211,14 @@ For the Stage 8 prover re-baseline, use the dedicated `prove_full` profile:
 julia --project=. benchmarks/run.jl --profile=stage8
 ```
 
+For the Stage 8A prover scalar-plumbing follow-through, use the dedicated
+profile or the exact group directly:
+
+```
+julia --project=. benchmarks/run.jl --profile=stage8a
+julia --project=. benchmarks/run.jl --groups=scalar_plumbing
+```
+
 Run a custom subset of groups when you need a tighter loop without changing the
 default full regression suite:
 
@@ -269,6 +281,46 @@ The Stage 8 result is therefore mixed: the new backend made final proof
 assembly meaningfully cheaper, but the primary larger fixture stayed flat
 overall because the MSM-heavy prover buckets did not improve with it.
 
+## Stage 8A Snapshot (2026-04-02)
+
+- Scalar-plumbing comparison:
+  `artifacts/2026-04-01_223814/results/benchmark_results.json`
+- Full re-baseline:
+  `artifacts/2026-04-01_223859/results/benchmark_results.json`
+- Profiles:
+  `artifacts/2026-04-01_223859/profiles/`
+
+This follow-through removes the prover’s hot `BN254Fr -> BigInt` scalar
+roundtrips and compares the old and new scalar paths directly before rerunning
+the Stage 8 `prove_full` fixture set.
+
+Scalar-plumbing comparison on the main deterministic fixture:
+
+- `scalar_mul(delta_g1, r)`: `0.737 ms -> 0.720 ms`
+- `scalar_mul(delta_g2, s)`: `2.442 ms -> 2.355 ms`
+- `A_query` MSM: `3.019 ms -> 2.937 ms`
+- `B_query_g2` MSM: `4.477 ms -> 4.299 ms`
+- `H` MSM: `7.198 ms -> 7.128 ms`
+- `L` MSM: `3.993 ms -> 3.873 ms`
+
+Relative to the first Stage 8 `prove_full` baseline
+`artifacts/2026-04-01_220953/results/benchmark_results.json`:
+
+- `generated_24_constraints`
+  - `prove_full` end-to-end: `30.088 ms -> 28.873 ms` (`-4.0%`)
+  - `msm_b_g2`: `4.714 ms -> 4.334 ms` (`-8.1%`)
+  - `h_msm`: `7.805 ms -> 7.036 ms` (`-9.9%`)
+  - `l_msm`: `4.210 ms -> 3.856 ms` (`-8.4%`)
+  - `final_c`: `3.001 ms -> 2.804 ms` (`-6.6%`)
+- `sum_of_products_small`
+  - `prove_full` end-to-end: `8.248 ms -> 8.614 ms` (`+4.4%`)
+
+The key profiler result is that the Stage 8A
+`prove_full_generated_24_constraints.txt` dump no longer contains
+`canonical_bigint` or `limbs_to_bigint`. The prover still creates `BigInt`s
+elsewhere, but the hot prover scalar conversions identified in Stage 8 have now
+been removed from the main `prove_full` path.
+
 Generate a full report (run -> plot -> compare) for latest run:
 
 ```
@@ -283,8 +335,9 @@ julia --project=. benchmarks/report.jl --skip-run --threshold=10
   tight feedback loop during primitive/backend optimization, use
   `--profile=stage3` when specifically iterating on `BN254Fr`
   polynomial/domain code, use `--profile=stage5` when iterating on direct
-  G1/G2 curve kernels and batch normalization, or use `--groups=...` for exact
-  family selection. The chosen profile/groups are recorded in `_meta`.
+  G1/G2 curve kernels and batch normalization, use `--profile=stage8a` when
+  iterating on prover scalar plumbing, or use `--groups=...` for exact family
+  selection. The chosen profile/groups are recorded in `_meta`.
 - The optional `py_ecc` comparison runs inside a dedicated Python process that
   times only the primitive loops after import/setup; it is skipped automatically
   when the sibling `py_ecc/` checkout is absent.

--- a/benchmarks/plot.jl
+++ b/benchmarks/plot.jl
@@ -124,6 +124,33 @@ function plot_single_ops(results::AbstractDict, out_dir::String, key::Symbol, or
     png(joinpath(out_dir, outfile))
 end
 
+function plot_scalar_plumbing_summary(results::AbstractDict, out_dir::String)
+    ops = [
+        ("scalar_plumbing_g1_scalar", "G1 scalar"),
+        ("scalar_plumbing_g2_scalar", "G2 scalar"),
+        ("scalar_plumbing_a_query_msm", "A query MSM"),
+        ("scalar_plumbing_b2_query_msm", "B2 query MSM"),
+        ("scalar_plumbing_h_msm", "H MSM"),
+        ("scalar_plumbing_l_msm", "L MSM"),
+    ]
+
+    present = [(key, label) for (key, label) in ops if haskey(results, key)]
+    isempty(present) && return
+
+    data = [median_ms(results[key][series]) for series in ("bigint", "bn254fr"), (key, _) in present]
+    groupedbar(
+        [label for (_, label) in present],
+        permutedims(data),
+        bar_position=:dodge,
+        legend=:topleft,
+        title="BN254Fr scalar plumbing: BigInt vs field scalars",
+        ylabel="median time (ms)",
+        label=["bigint" "bn254fr"],
+        xrotation=20,
+    )
+    png(joinpath(out_dir, "scalar_plumbing.png"))
+end
+
 function plot_prove_full_breakdowns(results::AbstractDict, out_dir::String)
     group = get(results, "prove_full", nothing)
     group === nothing && return
@@ -198,6 +225,7 @@ function main()
     plot_group(res, out_dir, :msm_tuning_g2, "MSM tuning G2 (median)",
         ["straus", "auto", "pippenger_w2", "pippenger_w3", "pippenger_w4", "pippenger_w5", "pippenger_w6"],
         "msm_tuning_g2.png")
+    plot_scalar_plumbing_summary(res, out_dir)
     plot_group(res, out_dir, :norm_g1, "Batch norm G1 (median)", ["each", "batch"], "norm_g1.png")
     plot_group(res, out_dir, :norm_g2, "Batch norm G2 (median)", ["each", "batch"], "norm_g2.png")
     plot_categorical_group(res, out_dir, :py_ecc_scalar, ["g1", "g2"], ["groth_jl", "py_ecc"],

--- a/benchmarks/prove_full_common.jl
+++ b/benchmarks/prove_full_common.jl
@@ -19,9 +19,7 @@ const PROVE_FULL_PHASE_ORDER = [
     "final_c",
 ]
 
-function field_to_int(x)
-    return Integer(x.value)
-end
+field_to_bigint(x) = convert(BigInt, x)
 
 function public_inputs_for(r1cs::R1CS, witness::Witness)
     return r1cs.num_public > 1 ? witness.values[2:r1cs.num_public] : eltype(witness.values)[]
@@ -171,10 +169,14 @@ function fixture_metadata(fixture)
 end
 
 function witness_to_scalars(witness::Witness)
+    return copy(witness.values)
+end
+
+function witness_to_scalars_bigint(witness::Witness)
     w_vals = witness.values
     scalars = Vector{BigInt}(undef, length(w_vals))
     @inbounds for i in eachindex(w_vals)
-        scalars[i] = field_to_int(w_vals[i])
+        scalars[i] = field_to_bigint(w_vals[i])
     end
     return scalars
 end
@@ -224,7 +226,7 @@ function sample_prove_randomizers(fixture)
     return sample_benchmark_field(F, rng), sample_benchmark_field(F, rng)
 end
 
-function prove_query_accumulators(pk::ProvingKey, scalars::Vector{<:Integer})
+function prove_query_accumulators(pk::ProvingKey, scalars::AbstractVector)
     return (
         A_acc_g1 = GrothAlgebra.multi_scalar_mul(pk.A_query_g1, scalars),
         B_acc_g1 = GrothAlgebra.multi_scalar_mul(pk.B_query_g1, scalars),
@@ -235,16 +237,15 @@ end
 function assemble_ab_terms(pk::ProvingKey, A_acc_g1, B_acc_g1, B_acc_g2, r, s)
     A1_g1 = pk.alpha_g1 + A_acc_g1
     B1_g1 = pk.beta_g1 + B_acc_g1
-    A = A1_g1 + scalar_mul(pk.delta_g1, field_to_int(r))
-    B = pk.beta_g2 + B_acc_g2 + scalar_mul(pk.delta_g2, field_to_int(s))
+    A = A1_g1 + scalar_mul(pk.delta_g1, r)
+    B = pk.beta_g2 + B_acc_g2 + scalar_mul(pk.delta_g2, s)
     return (A = A, B = B, A1_g1 = A1_g1, B1_g1 = B1_g1)
 end
 
 function h_msm(pk::ProvingKey, h_poly)
     hk = length(h_poly.coeffs)
     pts_h = pk.H_query_g1[1:hk]
-    scalars_h = [field_to_int(c) for c in h_poly.coeffs]
-    return GrothAlgebra.multi_scalar_mul(pts_h, scalars_h)
+    return GrothAlgebra.multi_scalar_mul(pts_h, h_poly.coeffs)
 end
 
 function l_msm(pk::ProvingKey, witness::Witness)
@@ -252,12 +253,12 @@ function l_msm(pk::ProvingKey, witness::Witness)
     if m <= pk.num_public
         return zero(G1Point)
     end
-    priv_scalars = [field_to_int(witness.values[i]) for i in (pk.num_public+1):m]
+    priv_scalars = witness.values[(pk.num_public+1):m]
     return GrothAlgebra.multi_scalar_mul(pk.L_query_g1, priv_scalars)
 end
 
 function assemble_c(pk::ProvingKey, A, B1_g1, H, L, r, s)
-    rs_delta = scalar_mul(pk.delta_g1, field_to_int(r * s))
-    g1_b_full = B1_g1 + scalar_mul(pk.delta_g1, field_to_int(s))
-    return H + L + scalar_mul(g1_b_full, field_to_int(r)) + scalar_mul(A, field_to_int(s)) - rs_delta
+    rs_delta = scalar_mul(pk.delta_g1, r * s)
+    g1_b_full = B1_g1 + scalar_mul(pk.delta_g1, s)
+    return H + L + scalar_mul(g1_b_full, r) + scalar_mul(A, s) - rs_delta
 end

--- a/benchmarks/run.jl
+++ b/benchmarks/run.jl
@@ -26,6 +26,7 @@ const BENCHMARK_GROUP_ORDER = [
     :fixed_base,
     :variable_msm,
     :scalar_msm_tuning,
+    :scalar_plumbing,
     :glv_scalar_tuning,
     :batch_norm,
     :pairing_throughput,
@@ -45,6 +46,7 @@ const BENCHMARK_PROFILES = Dict(
     "stage7" => [:bn254_primitives, :variable_msm, :scalar_msm_tuning, :prove_full],
     "stage7a" => [:bn254_primitives, :glv_scalar_tuning],
     "stage8" => [:prove_full],
+    "stage8a" => [:scalar_plumbing, :prove_full],
     "primitives" => [:bn254_primitives, :pairing_micro, :py_ecc_primitives],
 )
 
@@ -519,6 +521,113 @@ function bench_scalar_msm_tuning(results)
             record_result!(results, :msm_tuning_g2, string(N), label, tr)
         end
     end
+end
+
+function bench_scalar_plumbing(results)
+    println("\n== Stage 8A scalar plumbing: BigInt vs BN254Fr prover scalars ==")
+    fixture = only(filter(f -> f.name == "generated_24_constraints", default_prove_full_fixtures()))
+    pk = fixture.keypair.pk
+    witness = fixture.witness
+    qap = fixture.qap
+    r_rand, s_rand = sample_prove_randomizers(fixture)
+
+    witness_scalars_fr = witness_to_scalars(witness)
+    witness_scalars_bigint = witness_to_scalars_bigint(witness)
+    h_poly = compute_h_polynomial(qap, witness)
+    h_scalars_fr = h_poly.coeffs
+    h_scalars_bigint = map(field_to_bigint, h_poly.coeffs)
+    priv_scalars_fr = witness.values[(pk.num_public + 1):end]
+    priv_scalars_bigint = map(field_to_bigint, priv_scalars_fr)
+
+    g1_scalar_fr = r_rand
+    g1_scalar_bigint = field_to_bigint(r_rand)
+    g2_scalar_fr = s_rand
+    g2_scalar_bigint = field_to_bigint(s_rand)
+
+    msm_a_fr = GrothAlgebra.multi_scalar_mul(pk.A_query_g1, witness_scalars_fr)
+    msm_a_bigint = GrothAlgebra.multi_scalar_mul(pk.A_query_g1, witness_scalars_bigint)
+    msm_b2_fr = GrothAlgebra.multi_scalar_mul(pk.B_query_g2, witness_scalars_fr)
+    msm_b2_bigint = GrothAlgebra.multi_scalar_mul(pk.B_query_g2, witness_scalars_bigint)
+    h_msm_fr = GrothAlgebra.multi_scalar_mul(pk.H_query_g1[1:length(h_poly.coeffs)], h_scalars_fr)
+    h_msm_bigint = GrothAlgebra.multi_scalar_mul(pk.H_query_g1[1:length(h_poly.coeffs)], h_scalars_bigint)
+    l_msm_fr = GrothAlgebra.multi_scalar_mul(pk.L_query_g1, priv_scalars_fr)
+    l_msm_bigint = GrothAlgebra.multi_scalar_mul(pk.L_query_g1, priv_scalars_bigint)
+    g1_scalar_res_fr = scalar_mul(pk.delta_g1, g1_scalar_fr)
+    g1_scalar_res_bigint = scalar_mul(pk.delta_g1, g1_scalar_bigint)
+    g2_scalar_res_fr = scalar_mul(pk.delta_g2, g2_scalar_fr)
+    g2_scalar_res_bigint = scalar_mul(pk.delta_g2, g2_scalar_bigint)
+
+    msm_a_fr == msm_a_bigint || error("BN254Fr scalar plumbing changed A-query MSM result")
+    msm_b2_fr == msm_b2_bigint || error("BN254Fr scalar plumbing changed B2-query MSM result")
+    h_msm_fr == h_msm_bigint || error("BN254Fr scalar plumbing changed H MSM result")
+    l_msm_fr == l_msm_bigint || error("BN254Fr scalar plumbing changed L MSM result")
+    g1_scalar_res_fr == g1_scalar_res_bigint || error("BN254Fr scalar plumbing changed G1 scalar_mul result")
+    g2_scalar_res_fr == g2_scalar_res_bigint || error("BN254Fr scalar plumbing changed G2 scalar_mul result")
+
+    record_semantic!(results, :scalar_plumbing, "g1_scalar_delta", serialize_affine(g1_scalar_res_fr))
+    record_semantic!(results, :scalar_plumbing, "g2_scalar_delta", serialize_affine(g2_scalar_res_fr))
+    record_semantic!(results, :scalar_plumbing, "a_query_msm", serialize_affine(msm_a_fr))
+    record_semantic!(results, :scalar_plumbing, "b2_query_msm", serialize_affine(msm_b2_fr))
+    record_semantic!(results, :scalar_plumbing, "h_msm", serialize_affine(h_msm_fr))
+    record_semantic!(results, :scalar_plumbing, "l_msm", serialize_affine(l_msm_fr))
+
+    println("Fixture: ", fixture.name)
+    println("  constraints=$(fixture.r1cs.num_constraints) vars=$(fixture.r1cs.num_vars) public=$(fixture.r1cs.num_public) domain=$(qap.domain.size)")
+
+    _ = scalar_mul(pk.delta_g1, g1_scalar_bigint)
+    _ = scalar_mul(pk.delta_g1, g1_scalar_fr)
+    tr_g1_bigint = @benchmark scalar_mul($pk.delta_g1, $g1_scalar_bigint) seconds = 1 samples = 10
+    tr_g1_fr = @benchmark scalar_mul($pk.delta_g1, $g1_scalar_fr) seconds = 1 samples = 10
+    print_stats("scalar_plumbing G1 bigint", tr_g1_bigint)
+    print_stats("scalar_plumbing G1 bn254fr", tr_g1_fr)
+    record_simple!(results, :scalar_plumbing_g1_scalar, "bigint", tr_g1_bigint)
+    record_simple!(results, :scalar_plumbing_g1_scalar, "bn254fr", tr_g1_fr)
+
+    _ = scalar_mul(pk.delta_g2, g2_scalar_bigint)
+    _ = scalar_mul(pk.delta_g2, g2_scalar_fr)
+    tr_g2_bigint = @benchmark scalar_mul($pk.delta_g2, $g2_scalar_bigint) seconds = 1 samples = 10
+    tr_g2_fr = @benchmark scalar_mul($pk.delta_g2, $g2_scalar_fr) seconds = 1 samples = 10
+    print_stats("scalar_plumbing G2 bigint", tr_g2_bigint)
+    print_stats("scalar_plumbing G2 bn254fr", tr_g2_fr)
+    record_simple!(results, :scalar_plumbing_g2_scalar, "bigint", tr_g2_bigint)
+    record_simple!(results, :scalar_plumbing_g2_scalar, "bn254fr", tr_g2_fr)
+
+    _ = GrothAlgebra.multi_scalar_mul(pk.A_query_g1, witness_scalars_bigint)
+    _ = GrothAlgebra.multi_scalar_mul(pk.A_query_g1, witness_scalars_fr)
+    tr_msm_a_bigint = @benchmark GrothAlgebra.multi_scalar_mul($pk.A_query_g1, $witness_scalars_bigint) seconds = 1 samples = 10
+    tr_msm_a_fr = @benchmark GrothAlgebra.multi_scalar_mul($pk.A_query_g1, $witness_scalars_fr) seconds = 1 samples = 10
+    print_stats("scalar_plumbing A bigint", tr_msm_a_bigint)
+    print_stats("scalar_plumbing A bn254fr", tr_msm_a_fr)
+    record_simple!(results, :scalar_plumbing_a_query_msm, "bigint", tr_msm_a_bigint)
+    record_simple!(results, :scalar_plumbing_a_query_msm, "bn254fr", tr_msm_a_fr)
+
+    _ = GrothAlgebra.multi_scalar_mul(pk.B_query_g2, witness_scalars_bigint)
+    _ = GrothAlgebra.multi_scalar_mul(pk.B_query_g2, witness_scalars_fr)
+    tr_msm_b2_bigint = @benchmark GrothAlgebra.multi_scalar_mul($pk.B_query_g2, $witness_scalars_bigint) seconds = 1 samples = 10
+    tr_msm_b2_fr = @benchmark GrothAlgebra.multi_scalar_mul($pk.B_query_g2, $witness_scalars_fr) seconds = 1 samples = 10
+    print_stats("scalar_plumbing B2 bigint", tr_msm_b2_bigint)
+    print_stats("scalar_plumbing B2 bn254fr", tr_msm_b2_fr)
+    record_simple!(results, :scalar_plumbing_b2_query_msm, "bigint", tr_msm_b2_bigint)
+    record_simple!(results, :scalar_plumbing_b2_query_msm, "bn254fr", tr_msm_b2_fr)
+
+    h_pts = pk.H_query_g1[1:length(h_poly.coeffs)]
+    _ = GrothAlgebra.multi_scalar_mul(h_pts, h_scalars_bigint)
+    _ = GrothAlgebra.multi_scalar_mul(h_pts, h_scalars_fr)
+    tr_h_bigint = @benchmark GrothAlgebra.multi_scalar_mul($h_pts, $h_scalars_bigint) seconds = 1 samples = 10
+    tr_h_fr = @benchmark GrothAlgebra.multi_scalar_mul($h_pts, $h_scalars_fr) seconds = 1 samples = 10
+    print_stats("scalar_plumbing H bigint", tr_h_bigint)
+    print_stats("scalar_plumbing H bn254fr", tr_h_fr)
+    record_simple!(results, :scalar_plumbing_h_msm, "bigint", tr_h_bigint)
+    record_simple!(results, :scalar_plumbing_h_msm, "bn254fr", tr_h_fr)
+
+    _ = GrothAlgebra.multi_scalar_mul(pk.L_query_g1, priv_scalars_bigint)
+    _ = GrothAlgebra.multi_scalar_mul(pk.L_query_g1, priv_scalars_fr)
+    tr_l_bigint = @benchmark GrothAlgebra.multi_scalar_mul($pk.L_query_g1, $priv_scalars_bigint) seconds = 1 samples = 10
+    tr_l_fr = @benchmark GrothAlgebra.multi_scalar_mul($pk.L_query_g1, $priv_scalars_fr) seconds = 1 samples = 10
+    print_stats("scalar_plumbing L bigint", tr_l_bigint)
+    print_stats("scalar_plumbing L bn254fr", tr_l_fr)
+    record_simple!(results, :scalar_plumbing_l_msm, "bigint", tr_l_bigint)
+    record_simple!(results, :scalar_plumbing_l_msm, "bn254fr", tr_l_fr)
 end
 
 function bn254_stage7a_glv_inputs()
@@ -1369,6 +1478,7 @@ function main()
     :fixed_base in selected && bench_fixed_base(results)
     :variable_msm in selected && bench_variable_msm(results)
     :scalar_msm_tuning in selected && bench_scalar_msm_tuning(results)
+    :scalar_plumbing in selected && bench_scalar_plumbing(results)
     :glv_scalar_tuning in selected && bench_glv_scalar_tuning(results)
     :batch_norm in selected && bench_batch_norm(results)
     :pairing_throughput in selected && bench_pairing_throughput(results)

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -28,9 +28,11 @@ the latest artefacts.
    julia --project=. benchmarks/run.jl --profile=stage5
    julia --project=. benchmarks/run.jl --profile=stage7a
    julia --project=. benchmarks/run.jl --profile=stage8
+   julia --project=. benchmarks/run.jl --profile=stage8a
    julia --project=. benchmarks/run.jl --groups=bn254_primitives,bn254_polynomials,pairing_micro
    julia --project=. benchmarks/run.jl --groups=bn254_curve_kernels,batch_norm
    julia --project=. benchmarks/run.jl --groups=glv_scalar_tuning
+   julia --project=. benchmarks/run.jl --groups=scalar_plumbing
    ```
 
 3. Regenerate plots (latest run by default, or pass a run id / JSON file):
@@ -64,7 +66,7 @@ the latest artefacts.
 The harness writes a timestamped JSON (raw statistics) and PNG charts covering
 direct BN254 field and tower primitives, direct G1/G2 add-double-affine kernels,
 BN254 `Fr` polynomial/domain helpers, scalar multiplication, the Stage 7A GLV
-scalar sweep, MSM, pairing,
+scalar sweep, the Stage 8A prover scalar-plumbing comparison, MSM, pairing,
 normalisation, Groth16 end-to-end timings, and `prove_full` fixture
 breakdowns.
 The profiling script writes text profiler dumps under the same artifact tree,
@@ -110,6 +112,41 @@ fixture stayed effectively flat:
 So the backend rewrite clearly reduced final proof assembly cost, but the
 current prover baseline says the next real wins still need to come from the
 MSM-heavy prover buckets rather than from `final_c`.
+
+## Stage 8A Snapshot (2026‑04‑02)
+
+The Stage 8A scalar-plumbing follow-through artifacts are:
+
+- `benchmarks/artifacts/2026-04-01_223814/results/benchmark_results.json`
+- `benchmarks/artifacts/2026-04-01_223859/results/benchmark_results.json`
+
+Stage 8A removed the prover’s hot `BN254Fr -> BigInt` scalar conversions and
+then reran the `prove_full` baseline.
+
+On the direct scalar-plumbing comparison for the main deterministic fixture:
+
+- `scalar_mul(delta_g1, r)`: `0.737 ms -> 0.720 ms`
+- `scalar_mul(delta_g2, s)`: `2.442 ms -> 2.355 ms`
+- `A_query` MSM: `3.019 ms -> 2.937 ms`
+- `B_query_g2` MSM: `4.477 ms -> 4.299 ms`
+- `H` MSM: `7.198 ms -> 7.128 ms`
+- `L` MSM: `3.993 ms -> 3.873 ms`
+
+Relative to the first Stage 8 `prove_full` baseline (`2026-04-01_220953`):
+
+- `generated_24_constraints`
+  - `prove_full`: `30.088 ms -> 28.873 ms`
+  - `msm_b_g2`: `4.714 ms -> 4.334 ms`
+  - `h_msm`: `7.805 ms -> 7.036 ms`
+  - `l_msm`: `4.210 ms -> 3.856 ms`
+  - `final_c`: `3.001 ms -> 2.804 ms`
+- `sum_of_products_small`
+  - `prove_full`: `8.248 ms -> 8.614 ms`
+
+The most important profiler result is qualitative as well as quantitative: the
+main Stage 8A `prove_full` dump no longer contains `canonical_bigint` or
+`limbs_to_bigint`. The prover still creates `BigInt`s elsewhere, but the
+measured hot prover scalar-conversion path identified in Stage 8 is now gone.
 
 ## Latest Snapshot (2025‑09‑29)
 


### PR DESCRIPTION
## Summary
- add native `BN254Fr` scalar support in the group layer for scalar multiplication, MSM, and fixed-base batch multiplication
- remove the prover and setup hot-path `BN254Fr -> BigInt` roundtrips in `Groth16.jl`, while keeping the BN254 G1 GLV/hybrid path for field scalars
- add the Stage 8A scalar-plumbing benchmark/profile pass and record the results in the roadmap and benchmark docs

## Benchmark Results
Stage 8A scalar-plumbing comparison on the deterministic `generated_24_constraints` fixture:
- `scalar_mul(delta_g1, r)`: `0.737 ms -> 0.720 ms`
- `scalar_mul(delta_g2, s)`: `2.442 ms -> 2.355 ms`
- `A_query` MSM: `3.019 ms -> 2.937 ms`
- `B_query_g2` MSM: `4.477 ms -> 4.299 ms`
- `H` MSM: `7.198 ms -> 7.128 ms`
- `L` MSM: `3.993 ms -> 3.873 ms`

Relative to the first Stage 8 prover baseline (`2026-04-01_220953`), the full Stage 8A rerun (`2026-04-01_223859`) moved:
- `generated_24_constraints` `prove_full`: `30.088 ms -> 28.873 ms` (`-4.0%`)
- `msm_b_g2`: `4.714 ms -> 4.334 ms` (`-8.1%`)
- `h_msm`: `7.805 ms -> 7.036 ms` (`-9.9%`)
- `l_msm`: `4.210 ms -> 3.856 ms` (`-8.4%`)
- `final_c`: `3.001 ms -> 2.804 ms` (`-6.6%`)
- `sum_of_products_small` `prove_full`: `8.248 ms -> 8.614 ms` (`+4.4%`)

The refreshed `prove_full_generated_24_constraints` profile no longer contains `canonical_bigint` or `limbs_to_bigint`, so the hot prover scalar conversions identified in Stage 8 are gone from the main path.

## Validation
- `julia --project=GrothAlgebra -e 'using Pkg; Pkg.test()'`
- `julia --project=GrothCurves -e 'using Pkg; Pkg.test()'`
- `julia --project=GrothProofs -e 'using Pkg; Pkg.test()'`
- `julia --project=. benchmarks/run.jl --groups=scalar_plumbing`
- `julia --project=. benchmarks/run.jl --profile=stage8a`
- `julia --project=. benchmarks/plot.jl 2026-04-01_223859`
- `julia --project=. benchmarks/profile_prove_full.jl --run-id=2026-04-01_223859`
- `julia --project=. scripts/test_all.jl`
- `julia --project=docs docs/make.jl`