### PR TITLE
Refresh project positioning and stale overview docs

### DIFF
--- a/GrothAlgebra/src/FiniteFields.jl
+++ b/GrothAlgebra/src/FiniteFields.jl
@@ -381,6 +381,15 @@ end
 canonical_bigint(x::T) where {T<:MontgomeryFiniteFieldElement} =
     limbs_to_bigint(montgomery_decode_limbs(T, montgomery_storage(x)))
 
+"""
+    canonical_limbs(x::T) where {T<:MontgomeryFiniteFieldElement}
+
+Decode a Montgomery-backed field element into its canonical 4-limb little-endian
+representation.
+
+This is a low-level helper used by the BN254 scalar and MSM specializations to
+avoid round-tripping through `BigInt` in hot paths.
+"""
 @inline canonical_limbs(x::T) where {T<:MontgomeryFiniteFieldElement} =
     montgomery_decode_limbs(T, montgomery_storage(x))
 

--- a/GrothAlgebra/src/Group.jl
+++ b/GrothAlgebra/src/Group.jl
@@ -280,6 +280,15 @@ function _multi_scalar_mul_pippenger(points::Vector{G}, scalars::Vector{S}, max_
     return result
 end
 
+"""
+    multi_scalar_mul(points::Vector{G}, scalars::Vector{BN254Fr}) where {C,G<:GroupElem{C}}
+
+Compute `∑ᵢ scalars[i] * points[i]` for BN254 scalar-field elements without
+round-tripping the scalars through `BigInt`.
+
+The dispatcher decodes each scalar to canonical limbs once, then reuses the
+same Straus/Pippenger split as the generic integer MSM path.
+"""
 function multi_scalar_mul(points::Vector{G}, scalars::Vector{BN254Fr}) where {C,G<:GroupElem{C}}
     if length(points) != length(scalars)
         throw(ArgumentError("Points and scalars must have the same length"))
@@ -531,6 +540,12 @@ function wnaf_encode(k::Integer, w::Int=4)
     return k >= 0 ? naf : -naf
 end
 
+"""
+    wnaf_encode(k::BN254Fr, w::Int=4)
+
+Encode a BN254 scalar-field element in windowed non-adjacent form (w-NAF)
+without converting through `BigInt`.
+"""
 function wnaf_encode(k::BN254Fr, w::Int=4)
     if w < 2
         throw(ArgumentError("Window size must be at least 2"))
@@ -613,6 +628,14 @@ function scalar_mul_wnaf(P::GroupElem{C}, k::Integer, w::Int=4) where C
     return result
 end
 
+"""
+    scalar_mul_wnaf(P::GroupElem{C}, k::BN254Fr, w::Int=4) where C
+
+Multiply `P` by a BN254 scalar-field element using the limb-native w-NAF path.
+
+This mirrors the integer API while keeping the scalar in canonical limb form
+throughout recoding and evaluation.
+"""
 function scalar_mul_wnaf(P::GroupElem{C}, k::BN254Fr, w::Int=4) where C
     if iszero(k)
         return zero(P)
@@ -648,6 +671,14 @@ function scalar_mul_wnaf(P::GroupElem{C}, k::BN254Fr, w::Int=4) where C
     return result
 end
 
+"""
+    scalar_mul(P::GroupElem{C}, k::BN254Fr) where C
+
+Multiply `P` by a BN254 scalar-field element using the tuned BN254 scalar path.
+
+The dispatcher prefers w-NAF when a curve-specific window is available and
+otherwise falls back to a limb-native double-and-add scan.
+"""
 function scalar_mul(P::GroupElem{C}, k::BN254Fr) where C
     if iszero(k)
         return zero(P)

--- a/GrothCurves/src/BN254Curve.jl
+++ b/GrothCurves/src/BN254Curve.jl
@@ -124,12 +124,26 @@ function _glv_scalar_decomposition(k::Integer, coeffs::NTuple{4,BigInt})
     return ((k1 >= 0, abs(k1)), (k2 >= 0, abs(k2)))
 end
 
+"""
+    glv_scalar_decomposition(::Type{G1Point}, k::Integer)
+    glv_scalar_decomposition(::Type{G2Point}, k::Integer)
+
+Decompose a scalar into the signed two-term representation used by the BN254
+GLV scalar-multiplication path for the selected group.
+"""
 glv_scalar_decomposition(::Type{G1Point}, k::Integer) = _glv_scalar_decomposition(k, BN254_G1_GLV_DECOMP_MATRIX)
 glv_scalar_decomposition(::Type{G2Point}, k::Integer) = _glv_scalar_decomposition(k, BN254_G2_GLV_DECOMP_MATRIX)
 
 glv_lambda(::Type{G1Point}) = BN254_G1_GLV_LAMBDA
 glv_lambda(::Type{G2Point}) = BN254_G2_GLV_LAMBDA
 
+"""
+    glv_endomorphism(p::G1Point)
+    glv_endomorphism(p::G2Point)
+
+Apply the BN254 GLV endomorphism to a projective point in the corresponding
+subgroup.
+"""
 @inline function glv_endomorphism(p::G1Point)
     iszero(p) && return p
     return G1Point(x_coord(p) * BN254_GLV_BETA, y_coord(p), z_coord(p))
@@ -177,6 +191,13 @@ function _glv_joint_scalar_mul(p::P, coeffs, endo_p::P) where {P<:ProjectivePoin
     return acc
 end
 
+"""
+    glv_scalar_mul(p::P, k::Integer) where {P<:ProjectivePoint{BN254Curve}}
+    glv_scalar_mul(p::P, k::GrothAlgebra.BN254Fr) where {P<:ProjectivePoint{BN254Curve}}
+
+Multiply a BN254 point by `k` using the Gallant-Lambert-Vanstone decomposition
+and the curve-specific endomorphism.
+"""
 function glv_scalar_mul(p::P, k::Integer) where {P<:ProjectivePoint{BN254Curve}}
     if k == 0
         return zero(p)
@@ -204,6 +225,15 @@ function glv_scalar_mul(p::P, k::GrothAlgebra.BN254Fr) where {P<:ProjectivePoint
     return _glv_joint_scalar_mul(p, coeffs, glv_endomorphism(p))
 end
 
+"""
+    GrothAlgebra.scalar_mul(p::G1Point, k::Integer)
+    GrothAlgebra.scalar_mul(p::G1Point, k::GrothAlgebra.BN254Fr)
+
+BN254 G1 scalar multiplication dispatcher.
+
+Small and medium scalars stay on the tuned w-NAF path, while larger scalars use
+the GLV path once the measured threshold is reached.
+"""
 function GrothAlgebra.scalar_mul(p::G1Point, k::Integer)
     if k == 0
         return zero(p)

--- a/README.md
+++ b/README.md
@@ -1,173 +1,139 @@
-```
-                    ╔═══════════════════════════════════════════════════╗
-                    ║                                                   ║
-                    ║    ▄████  ██▀███   ▒█████  ▄▄▄█████▓ ██░ ██     ║
-                    ║   ██▒ ▀█▒▓██ ▒ ██▒▒██▒  ██▒▓  ██▒ ▓▒▓██░ ██▒    ║
-                    ║  ▒██░▄▄▄░▓██ ░▄█ ▒▒██░  ██▒▒ ▓██░ ▒░▒██▀▀██░    ║
-                    ║  ░▓█  ██▓▒██▀▀█▄  ▒██   ██░░ ▓██▓ ░ ░▓█ ░██     ║
-                    ║  ░▒▓███▀▒░██▓ ▒██▒░ ████▓▒░  ▒██▒ ░ ░▓█▒░██▓    ║
-                    ║   ░▒   ▒ ░ ▒▓ ░▒▓░░ ▒░▒░▒░   ▒ ░░    ▒ ░░▒░▒    ║
-                    ║    ░   ░   ░▒ ░ ▒░  ░ ▒ ▒░     ░     ▒ ░▒░ ░    ║
-                    ║  ░ ░   ░   ░░   ░ ░ ░ ░ ▒    ░       ░  ░░ ░    ║
-                    ║        ░    ░         ░ ░             ░  ░  ░    ║
-                    ╚═══════════════════════════════════════════════════╝
-                          ∴‥∵‥∴ zkSNARK SUPREMACY ∴‥∵‥∴
-
-                    ░▒▓█►  ρяσνє єνєяутнιηg, яєνєαℓ ησтнιηg  ◄█▓▒░
-
-         ╔═════════════════════════════════════════════════════════════╗
-         ║  "In cryptography we trust, in zero-knowledge we thrive"   ║
-         ║              ∞ milady privacy maximalism ∞                 ║
-         ╚═════════════════════════════════════════════════════════════╝
-
-                        ▓▓▓▓▓▓▓   ▓▓▓▓▓▓▓
-                       ▓       ▓ ▓       ▓    ┌─────────────┐
-                       ▓  ╳ ╳  ▓ ▓  ╳ ╳  ▓    │ COMMITMENT  │
-                       ▓       ▓ ▓       ▓    │   HIDDEN    │
-                        ▓     ▓   ▓     ▓     │  KNOWLEDGE  │
-                         ▓▓▓▓▓     ▓▓▓▓▓      └─────────────┘
-                           ║         ║
-                        ═══╬═════════╬═══
-                           ║         ║
-                     ╔═════╩═════════╩═════╗
-                     ║  TRUSTED SETUP CULT  ║
-                     ╚═════════════════════╝
-```
-
 # Groth.jl
 
-Research-focused, modular implementation of the Groth16 zero-knowledge proof system in Julia.
-This repository explores cryptographic primitives (finite fields, curves, pairings) and the Groth16 protocol end-to-end in Julia. It is a research codebase and **not** production software.
+Groth.jl is a Julia research platform for **BN254 algebra, pairings, and
+Groth16**.
 
-## Repository layout
+It combines:
 
-```
+- inspectable finite-field, extension-field, curve, and pairing code
+- an end-to-end Groth16 setup / prove / verify pipeline
+- benchmark and profiling infrastructure for prover hot paths
+- Pluto-first educational material alongside performance-oriented engineering
+
+This repository is **research-grade, not production software**. The goals are
+clarity, mathematical correctness, REPL ergonomics, and serious performance
+work without hiding the underlying algebra.
+
+## What Is Implemented
+
+- **GrothAlgebra**
+  - BN254 `Fq` / `Fr` on a fixed-width Montgomery backend
+  - generic polynomial utilities, cached evaluation domains, FFT / inverse FFT
+  - variable-base MSM, fixed-base tables, and scalar-multiplication helpers
+- **GrothCurves**
+  - BN254 `Fp2` / `Fp6` / `Fp12`
+  - G1 / G2 Jacobian arithmetic and batch normalization
+  - optimal ate pairing with Miller loop and final exponentiation
+- **GrothProofs**
+  - R1CS and QAP conversion
+  - Groth16 setup, proving, verification, and prepared-verifier flow
+  - deterministic benchmark fixtures for `prove_full`
+- **Benchmarks and docs**
+  - reproducible JSON/PNG benchmark artifacts
+  - primitive comparisons against `py_ecc` and local arkworks harnesses
+  - roadmap and implementation notes tied to measured performance work
+
+## Current Status
+
+The project has moved well beyond a minimal Groth16 demo.
+
+- BN254 primitives no longer run on the original `BigInt` hot path; the main
+  backend is now Montgomery-based.
+- Primitive benchmarks currently beat `py_ecc` across the tracked BN254 suite.
+- The gap to arkworks has narrowed substantially, but arkworks is still ahead.
+- The current larger deterministic `prove_full` baseline is `28.873 ms` in
+  [benchmarks/artifacts/2026-04-01_223859](./benchmarks/artifacts/2026-04-01_223859),
+  down from the original `136.187 ms` baseline captured at the start of the
+  performance investigation.
+- The active roadmap has shifted from broad backend replacement to targeted
+  specialization: limb-native inversion, final-exponentiation work, safer G2
+  GLV exposure, prover-shaped MSM tuning, and then a fresh prover re-baseline.
+
+See [ROADMAP.md](./ROADMAP.md) for the staged backend history and remaining
+specialization work.
+
+## Repository Layout
+
+```text
 Groth.jl/
- ├── GrothAlgebra/   # finite fields, polynomials, group utilities
- ├── GrothCurves/    # BN254 curve + pairing engine
- ├── GrothProofs/    # R1CS, QAP, Groth16 prover/verifier
- ├── GrothExamples/  # Pluto notebooks and walkthroughs
- ├── GrothCrypto/    # placeholder for higher-level protocols
- ├── benchmarks/     # BenchmarkTools environment + plots
- └── docs/           # Roadmap, package reference, arkworks mapping
+├── GrothAlgebra/   # finite fields, polynomials, group utilities
+├── GrothCurves/    # BN254 tower fields, curve arithmetic, pairing engine
+├── GrothProofs/    # R1CS, QAP, Groth16 prover / verifier
+├── GrothExamples/  # Pluto notebooks and walkthroughs
+├── GrothCrypto/    # higher-level protocol space
+├── benchmarks/     # BenchmarkTools environment, plots, profiling scripts
+└── docs/           # reference docs, benchmarks, implementation notes
 ```
 
-- `docs/PACKAGE_REFERENCE.md` — per-package summary, key modules, follow-ups
-- `docs/Implementation_vs_Arkworks.md` — how our implementation compares to
-  arkworks (domains, MSM, pairing, Groth16 pipeline)
-- `docs/ROADMAP.md` — current priorities and completed milestones
-- `docs/RareSkills_Groth16_Map.md` — link between the RareSkills ZK book and
-  the Julia code
+The sibling repositories in the workspace, such as `ark-works/`, `py_ecc/`,
+and `zk-book/`, are reference checkouts. Active development happens in
+`Groth.jl/`.
 
-The sibling repositories `ark-works/` and `zk-book/` are reference checkouts
-only; all active work lives in `Groth.jl/`.
+## Quick Start
 
-## Getting started
-
-```
-# workspace setup (canonical)
+```bash
+# canonical workspace setup
 julia --project=. -e 'using Pkg; Pkg.instantiate(workspace=true)'
 
-# run all package tests (canonical)
+# canonical full validation
 julia --project=. scripts/test_all.jl
 
-# package-scoped alternatives (when needed)
+# package-scoped validation when intentionally narrowed
 julia --project=GrothAlgebra -e 'using Pkg; Pkg.test()'
+julia --project=GrothCurves -e 'using Pkg; Pkg.test()'
 julia --project=GrothProofs -e 'using Pkg; Pkg.test()'
 
-# benchmarks
-julia --project=. benchmarks/run.jl
+# benchmark harness
+julia --project=. benchmarks/run.jl --list-profiles
+julia --project=. benchmarks/run.jl --profile=quick
 julia --project=. benchmarks/plot.jl
+
+# docs
+julia --project=docs docs/make.jl
 ```
 
-Key tutorials live in `GrothExamples/` as Pluto notebooks (starting with
-`src/r1cs_qap_pluto.jl` and `src/r1cs_qap_groth_pluto.jl`).
+Key notebooks live in `GrothExamples/`, starting with:
 
-## Project status
+- `src/r1cs_qap_pluto.jl`
+- `src/r1cs_qap_groth_pluto.jl`
 
-- **GrothAlgebra** — prime fields, polynomial utilities, MSM helpers. Coset FFT
-  path uses coefficient-first padding; domain alignment with arkworks is the
-  next major task.
-- **GrothCurves** — BN254 tower, Jacobian curve ops, optimal ate pairing, and
-  a pairing-engine abstraction ready for additional curves.
-- **GrothProofs** — R1CS/QAP conversion, Groth16 setup/prove/verify mirroring
-  arkworks. Coset FFT path is default; dense path retained only for assertions.
-- **Benchmarks** — `benchmarks/results_2025-09-29_121914.json` captures the
-  current coset-enabled timings; plots regenerated via `benchmarks/plot.jl`.
+## Documentation Map
 
-See `docs/ROADMAP.md` for detailed milestones and follow-up work (domain
-alignment, MSM optimisations, second curve prototype, proof aggregation).
+- [ROADMAP.md](./ROADMAP.md) — staged BN254 backend roadmap and remaining work
+- [benchmarks/README.md](./benchmarks/README.md) — benchmark methodology and
+  current artifacts
+- [docs/src/benchmarks.md](./docs/src/benchmarks.md) — docs-site benchmark page
+- [docs/PACKAGE_REFERENCE.md](./docs/PACKAGE_REFERENCE.md) — package-level
+  reference and repository notes
+- [docs/Implementation_vs_Arkworks.md](./docs/Implementation_vs_Arkworks.md) —
+  structural comparison with arkworks
+- [docs/RareSkills_Groth16_Map.md](./docs/RareSkills_Groth16_Map.md) —
+  textbook-to-code mapping
 
-## Development guidelines
+## Performance Snapshot
 
-- Follow Julia style conventions: 4-space indent, `lowercase_with_underscores`
-  for functions, docstrings on exported methods, and dispatch-friendly
-  signatures that match existing APIs.
-- Run the relevant `Pkg.test()` suites and update benchmarks when performance
-  changes.
-- Use concise imperative commit messages (e.g., `groth16: align coset domain`).
-- Keep tutorial/docs in sync when user-visible output changes; the docs listed
-  above are the canonical references.
+Groth.jl now has two useful external reference points:
+
+- **vs `py_ecc`**: current primitive benchmarks put Groth.jl ahead across the
+  tracked BN254 scalar, accumulation, and pairing suite
+- **vs arkworks**: Groth.jl has narrowed the gap sharply since the initial
+  `BigInt` backend, but arkworks remains the stronger performance target
+
+This repo is therefore best understood as:
+
+- a serious Julia implementation of BN254 algebra, pairings, and Groth16
+- a research and optimization platform
+- not yet a drop-in replacement for a production Rust stack
+
+## Development Notes
+
+- Follow the repo and workspace `AGENTS.md` files.
+- Use `execplans/` for non-trivial work.
+- Keep benchmarks and docs in sync with user-visible behavior and measured
+  performance changes.
+- Prefer measured claims over aspirational ones.
 
 ## References
 
-- [arkworks](https://github.com/arkworks-rs) (Groth16 and algebra implementations)
+- [arkworks](https://github.com/arkworks-rs)
 - [RareSkills Zero Knowledge Book](https://github.com/zkCollective/zk-book)
-
-This repo explores cryptographic primitives (finite fields, curves, pairings) and the Groth16 protocol end-to-end in Julia.
-
-Note: This project is for research and experimentation. It is not intended for production use.
-
-## Project Structure
-
-This is a monorepo containing several interconnected Julia packages:
-
-### Core Packages
-
-- **[GrothAlgebra](./GrothAlgebra)** - Foundation package with finite field arithmetic, polynomial operations, and group theory primitives
-- **[GrothCurves](./GrothCurves)** - Elliptic curve implementations, focusing on BN254 (alt-bn128) with pairing support
-- **[GrothProofs](./GrothProofs)** - Zero-knowledge proof systems including R1CS, QAP conversion, and Groth16 implementation
-- **[GrothCrypto](./GrothCrypto)** - High-level cryptographic protocols built on top of the primitives
-- **[GrothExamples](./GrothExamples)** - Educational Pluto notebooks and demonstrations
-
-### Documentation & Tools
-
-- **[docs/](./docs)** - Project documentation including the RareSkills→Groth16 map and polishing roadmap
-- **[benchmarks/](./benchmarks)** - Performance benchmarks across packages
-
-## Status Overview
-
-- Algebra (GrothAlgebra)
-  - Prime fields (Fp) and scalar field (Fr) implementations; polynomial arithmetic with interpolation and evaluation.
-  - FFT/NTT and roots-of-unity domain planned (not yet implemented).
-- Curves & Pairing (GrothCurves)
-  - BN254 G1/G2 with Fp2/Fp6/Fp12 tower, optimal ate Miller loop, and final exponentiation.
-  - Pairing engine abstraction (`AbstractPairingEngine`, `BN254Engine`) to support future curves while keeping BN254 optimized.
-- Proofs (GrothProofs)
-  - R1CS and QAP conversion in Fr; end-to-end Groth16 (CRS, prover, verifier) aligned with arkworks structure and equations.
-  - Verifier enforces on-curve and subgroup checks; prepared verifier path batches pairings through the engine interface.
-- Examples (GrothExamples)
-  - Notebook-based walkthroughs (starting with toy R1CS -> QAP in Pluto).
-
-## Roadmap Highlights
-
-- Grow curve/generalization support: extend the pairing-engine interface to additional curves and trait-style abstractions.
-- FFT/NTT + roots-of-unity domain for QAP and faster polynomial ops.
-- MSM, fixed-base tables, and threaded hot paths for the prover plus batch normalization of CRS elements.
-- Documentation polish: Documenter.jl site, Pluto notebooks, and contributor guides for multiple dispatch patterns.
-
-## Pairing Engine Interface
-
-- Depend on `AbstractPairingEngine` (re-exported by `GrothCurves`) when writing code that needs pairings. The interface consists of `miller_loop`, `final_exponentiation`, `pairing`, and `pairing_batch` methods specialised on an engine type parameterised by the curve family.
-- `BN254Engine` is the default zero-sized backend; use the explicit form `pairing(BN254_ENGINE, P, Q)` or pass `engine=BN254_ENGINE` into helpers such as `GrothProofs.setup_full`. Convenience overloads without the engine argument remain available for interactive use.
-- The engine test harness lives in `GrothCurves/test/test_pairing_engine_interface.jl` and checks zero-handling, bilinearity, and batch pairing consistency. Mirror those checks when introducing additional engines.
-
-## Development
-
-- This is a research project: APIs may evolve. Not for production use.
-- Each package is a standalone Julia project with its own tests and docs.
-
-## References
-
-- arkworks-rs (groth16, algebra, relations)
-- RareSkills ZK Book

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,11 +63,12 @@ Completed stages:
 
 Next concrete work:
 
-- target the remaining measured `BigInt` / GMP work that still appears after
-  Stage 8A, starting with limb-native inversion and final-exponentiation
-  specialization
-- then re-evaluate the next highest-value prover bottleneck from the updated
-  `prove_full` profile instead of assuming the next win is only in MSM
+- execute the remaining targeted specialization roadmap below, starting with
+  limb-native inversion and final-exponentiation specialization
+- re-baseline `prove_full` after each high-leverage specialization stage rather
+  than batching multiple changes and losing attribution
+- leave Stage 9 parallelism and accelerator work until the current
+  single-thread backend bottlenecks are tighter
 
 Stage 8 remains the end-to-end `prove_full` integration and regression
 baseline stage.
@@ -498,16 +499,187 @@ The current BN254 primitive gap to arkworks is no longer dominated by the old
 
 Current priority order for narrowing that gap:
 
-1. Stage 8 `prove_full` re-baseline on the new backend
-2. limb-native inversion
-3. final-exponentiation specialization
-4. more in-place extension-field helpers
-5. subgroup-aware G2 typing or another safe way to expose G2 GLV by default
-6. deeper MSM specialization
+1. limb-native inversion
+2. final-exponentiation specialization
+3. more in-place extension-field helpers
+4. subgroup-aware G2 typing or another safe way to expose G2 GLV by default
+5. deeper MSM specialization on prover-shaped workloads
+6. post-specialization `prove_full` re-baseline
 
-This gap-narrowing track is intentionally placed before Stage 8 so the next
-`prove_full` baseline benefits from the higher-value primitive improvements
-first.
+The scalar-plumbing win in Stage 8A removed the measured
+`canonical_bigint` / `limbs_to_bigint` prover conversions, but the current
+profile still shows other `BigInt` / GMP activity. The next roadmap therefore
+focuses on the remaining low-level escape hatches and on the prover buckets
+that are still largest after Stage 8A.
+
+## Remaining Targeted Specialization Work
+
+This section is the post-Stage-8A execution ladder. Each work package is small
+enough to become its own ExecPlan.
+
+### Work Package 1: Limb-Native Inversion
+
+Goal:
+Replace the current `BigInt invmod` path in the Montgomery backend with a
+limb-native inversion algorithm for `BN254Fq` and `BN254Fr`.
+
+Why this is first:
+
+- it is still a direct `BigInt` / GMP escape hatch in the arithmetic backend
+- inversion sits under `batch_to_affine!`, verifier prep, and the easy part of
+  final exponentiation
+- it should reduce both primitive and prover overhead without changing API
+
+Primary measurements:
+
+- `BN254Fq inv`
+- `BN254Fr inv`
+- `batch_to_affine!`
+- `final_exponentiation_easy`
+- `prove_full final_c`
+
+Exit criteria:
+
+- no `BigInt invmod` in the main inversion path
+- field and pairing invariants still pass
+- measurable improvement in inversion-heavy primitive or prover buckets
+
+### Work Package 2: Final-Exponentiation Specialization
+
+Goal:
+Specialize the hard final-exponentiation path around cyclotomic operations and
+measured BN254 structure instead of generic `Fp12` multiplication/squaring.
+
+Why this is next:
+
+- the arkworks gap is still visible in final exponentiation
+- Stage 6 improved pairing a lot, but final exponentiation is still one of the
+  clearest remaining primitive specialization opportunities
+
+Primary measurements:
+
+- `final_exponentiation`
+- `final_exponentiation_hard`
+- `exp_by_u`
+- full `pairing`
+
+Exit criteria:
+
+- no semantic drift in GT outputs or bilinearity tests
+- final exponentiation moves materially on the primitive benchmark
+- the pairing gap to arkworks narrows further
+
+### Work Package 3: In-Place Extension-Field Hot Paths
+
+Goal:
+Reduce temporary construction and value churn in `Fp2`, `Fp6`, and `Fp12`
+operations that are still hot inside Miller-loop and final-exponentiation code.
+
+Why this is separate:
+
+- it is easy to blur together with Work Package 2, but the risk surface is
+  broader and should be measured independently
+- the current remaining gap is partly about API shape and allocation behavior,
+  not only formulas
+
+Primary measurements:
+
+- `doubling_step`
+- `addition_step`
+- `evaluate_line`
+- `miller_loop`
+- allocation counts in the pairing-substep profiles
+
+Exit criteria:
+
+- fewer allocations or temporary values in pairing hot paths
+- measurable improvement in Miller loop and/or final exponentiation
+- no loss of readability around the core formulas without benchmark evidence
+
+### Work Package 4: Safe G2 GLV Exposure
+
+Goal:
+Find a safe way to use the existing G2 GLV acceleration where subgroup
+membership is actually guaranteed.
+
+Why this matters:
+
+- Stage 7A showed that G2 GLV helps on full-width subgroup scalars
+- the current blocker is semantic safety, not missing arithmetic support
+
+Possible directions:
+
+- subgroup-aware internal point wrapper types
+- explicit trusted-subgroup internal APIs for setup/prover-owned query points
+- another documented safety boundary that does not weaken public semantics
+
+Primary measurements:
+
+- G2 scalar benchmarks on real subgroup points
+- prover-owned G2 query workloads
+- `msm_b_g2` in `prove_full`
+
+Exit criteria:
+
+- no semantic weakening for public `G2Point` APIs
+- a documented safe boundary for GLV-enabled G2 multiplication
+- measurable win on the real prover G2 buckets
+
+### Work Package 5: Prover-Shaped MSM Specialization
+
+Goal:
+Specialize MSM further for the actual scalar and point distributions used by
+`prove_full`, rather than only for synthetic generic benchmarks.
+
+Why this is later:
+
+- Stage 7 and Stage 8A already moved generic MSM and scalar plumbing
+- the next MSM wins should be driven by the current `prove_full` fixture data,
+  not by abstract “MSM should be faster” intuition
+
+Primary measurements:
+
+- `msm_b_g2`
+- `h_msm`
+- `l_msm`
+- dedicated scalar-plumbing and prover-query benchmarks
+
+Possible directions:
+
+- BN254Fr-aware bucket handling and scalar decoding reuse
+- small-size and prover-shaped window retuning
+- internal use of safe subgroup-aware G2 GLV if Work Package 4 lands first
+- less-generic prover-owned MSM helpers where that materially helps
+
+Exit criteria:
+
+- measurable improvement in the largest remaining `prove_full` MSM buckets
+- no regression on the deterministic prover fixtures
+- benchmark evidence tied to the actual prover workloads
+
+### Work Package 6: Post-Specialization `prove_full` Re-Baseline
+
+Goal:
+Re-run the end-to-end `prove_full` benchmark and profiling workflow after the
+targeted specialization passes above.
+
+Why this is a separate work package:
+
+- it is the only honest way to determine which specialization work actually
+  paid off in the prover
+- it keeps the roadmap disciplined: measure, then choose the next stage
+
+Primary measurements:
+
+- Stage 8A baseline artifact `benchmarks/artifacts/2026-04-01_223859`
+- the next full `prove_full` artifact produced after Work Packages 1–5
+
+Exit criteria:
+
+- updated hotspot ranking for `prove_full`
+- explicit attribution of which remaining primitive/backend changes mattered
+- a clear decision on whether the next best move is more single-thread
+  specialization or Stage 9 parallelism
 
 ## Stage 8: `prove_full` Integration And Regression Baseline
 

--- a/docs/PACKAGE_REFERENCE.md
+++ b/docs/PACKAGE_REFERENCE.md
@@ -34,8 +34,9 @@ annotated rather than discarded), and follow-ups.
   coset paths reuse the new Montgomery backend without extra setup/copy work.
 
 **Follow-ups**
-- Evaluate FFT twiddle caching / mixed-radix support once the QAP domain aligns
-  with arkworks.
+- Replace the remaining `BigInt`-based inversion path for BN254.
+- Keep prover-shaped MSM follow-through tied to the deterministic benchmark
+  fixtures.
 
 ## GrothCurves
 
@@ -84,12 +85,13 @@ annotated rather than discarded), and follow-ups.
 - (2025-09-29) Coset path is default; dense vs coset equality asserted. Subset
   domains recover coefficients via barycentric interpolation before FFT (dense
   fallback retained for tests).
-- (TODO) Align evaluation domain population with arkworks (fill entire domain,
-  drop barycentric shim).
+- (2026-04-02) The current follow-through work has shifted from broad backend
+  migration to the remaining prover and pairing specialization steps surfaced
+  by the Stage 8A baseline.
 
 **Follow-ups**
 - Optional proof aggregation (arkworks-style) if bandwidth savings are needed.
-- Execute the domain-alignment work tracked in `docs/ROADMAP.md`.
+- Execute the remaining targeted specialization work tracked in `ROADMAP.md`.
 
 ## GrothExamples
 
@@ -113,12 +115,12 @@ annotated rather than discarded), and follow-ups.
 - The benchmark harness now includes a dedicated `bn254_curve_kernels` family
   for direct G1/G2 add, double, and `to_affine` timings, alongside the Stage 5
   `batch_to_affine!` normalization families.
-- The focused backend profiles are now `quick`, `stage3`, and `stage5`, with
-  `stage5` covering `bn254_primitives`, `bn254_curve_kernels`, `batch_norm`,
-  and `pairing_micro`.
-- Latest Stage 5 artifact: `benchmarks/artifacts/2026-04-01_154740`, with
-  `G1 scalar` at `105.483 μs`, `G2 scalar` at `226.369 μs`, and full pairing at
-  `3.892 ms`.
+- The focused backend profiles are now staged through `stage8a`, with
+  deterministic prover fixtures and `_semantic` proof checks wired into the
+  `prove_full` path.
+- Latest Stage 8A artifact: `benchmarks/artifacts/2026-04-01_223859`, with
+  `generated_24_constraints prove_full` at `28.873 ms`, `msm_b_g2` at
+  `4.334 ms`, `h_msm` at `7.036 ms`, and `final_c` at `2.804 ms`.
 
 ## Docs
 
@@ -126,10 +128,13 @@ annotated rather than discarded), and follow-ups.
 - `docs/Implementation_vs_Arkworks.md` — Compare implementation choices with
   arkworks.
 
-## Roadmap snapshot (see `docs/ROADMAP.md`)
+## Roadmap snapshot (see `ROADMAP.md`)
 
-- Immediate: align QAP domain population with arkworks.
-- Stretch: proof aggregation, pairing optimisations, second curve prototype.
+- Immediate: limb-native inversion, final-exponentiation specialization,
+  extension-field hot paths, safe G2 GLV exposure, and prover-shaped MSM
+  specialization.
+- Stretch: proof aggregation, second curve prototype, then Stage 9
+  parallelism / accelerators once the single-thread backend is tighter.
 
 ## Backend Migration Notes
 
@@ -139,120 +144,6 @@ annotated rather than discarded), and follow-ups.
   Generic `GaloisField{p}` and `Secp256k1Field` still use the default `BigInt`
   path.
 - Canonical integer conversion remains stable via `convert(BigInt, x)`.
-
----
-
-# Groth.jl — Repository Status and Pairings-Oriented Overview
-
-This document summarizes what’s implemented and well-documented in the repository, clarifies the mathematics versus representation and algorithm choices (with an emphasis on BN254 extension fields and pairings), and outlines concrete next steps to complete a functional Groth16 stack. Inline references point to files in this repo.
-
-## Executive Summary
-
-- Solid foundation in finite fields, basic algebra, and polynomials: clear, documented implementations with tests in `GrothAlgebra`.
-- BN254 curve, extension fields, and the BN254 optimal ate pairing are implemented end-to-end in `GrothCurves`:
-  - Fp2/Fp6/Fp12 extension tower with explicit formulas and optimized squarings.
-  - G1/G2 in Jacobian coordinates with addition/doubling.
-  - Miller loop with D-twist line placement and Frobenius correction steps.
-  - Final exponentiation (easy + hard parts) with Frobenius maps and precomputed twist constants.
-  - A large test suite exists under `GrothCurves/test` (good sign of maturity).
-- R1CS and QAP conversion are present and readable in `GrothProofs`, but QAP uses a simplified evaluation domain and the Groth16 is a demonstrative, simplified version (not the full scheme yet).
-
-Overall, the pairing stack looks coherent and well structured; the proof system side needs domain/FFT upgrades and a production-level Groth16 (setup/prove/verify) to align with the mathematical design.
-
-## What’s Well Implemented and Documented
-
-- Finite fields and polynomials (GrothAlgebra)
-  - `GrothAlgebra/src/FiniteFields.jl`: BigInt-backed prime fields (BN254 prime, secp256k1, and `GaloisField{p}`) with normalized arithmetic, inversion via `invmod`, power via `powermod`, plus helpful display and utilities. Clean docstrings and straightforward APIs.
-  - `GrothAlgebra/src/Polynomial.jl`: Polynomials over a field with degree/leading coefficient handling, Horner evaluation, Lagrange interpolation, derivative, and a placeholder for FFT multiply. Well commented; operations are correct and readable.
-- `GrothAlgebra/src/Group.jl`: A generic `GroupElem` interface with scalar multiplication, w-NAF utilities, a Pippenger-backed variable-base MSM with Straus fallback, and helpers. Clear documentation of expectations from concrete curve types.
-
-- BN254 extension tower and curve arithmetic (GrothCurves)
-  - `GrothCurves/src/BN254Fp2.jl`: Fp2 with u² = −1; real/imag accessors, conjugate, norm, inverse, Frobenius as conjugation. Docstrings explain representation and formulas.
-  - `GrothCurves/src/BN254Fp6_3over2.jl`: Fp6 over Fp2 via v³ = ξ with ξ = 9 + u (D-twist nonresidue). Uses Karatsuba-like multiplication and optimized squaring. Includes a clear `inv` via norm decomposition.
-  - `GrothCurves/src/BN254Fp12_2over6.jl`: Fp12 over Fp6 via w² = v. Optimized squaring and inversion, conjugation, and a baseline Frobenius (later enhanced by final exponentiation module).
-  - `GrothCurves/src/BN254Curve.jl`: G1 (over Fp) and G2 (over Fp2) in Jacobian coordinates with addition/doubling, affine conversion, curve membership checks, and standard generators. Nicely separated and easy to follow.
-  - `GrothCurves/src/BN254MillerLoop.jl`: Miller loop for the optimal ate pairing on BN254.
-    - D-twist line placement with explicit coefficient ordering, mixed addition, and careful mapping to sparse Fp12 coordinates in `evaluate_line`.
-    - Frobenius-based endomorphism on G2 using constants (`P_POWER_ENDOMORPHISM_COEFF_*`) from known references, and the NAF loop count for u.
-  - `GrothCurves/src/BN254FinalExp.jl`: Final exponentiation split into easy and hard parts.
-    - Precomputes sextic-twist Frobenius `γ` constants (GAMMA1/2/3) and provides `frobenius_p1/p2/p3` for Fp12.
-    - Implements the standard BN254 exponentiation ladder (`exp_by_u`, y₀..y₆ combination) consistent with literature.
-  - `GrothCurves/src/BN254Pairing.jl`: Composes Miller loop + final exponentiation into `optimal_ate_pairing`, plus batch pairing.
-
-- R1CS and QAP (GrothProofs)
-  - `GrothProofs/src/R1CS.jl`: Clean R1CS representation with constraint checking and an example circuit (r = x·y·z·u). Well-documented and approachable.
-  - `GrothProofs/src/QAP.jl`: Readable R1CS→QAP conversion via Lagrange interpolation and direct polynomial division for h(x). The domain is simplified to integers `[1..n]` (works for pedagogy; needs true roots-of-unity domain for FFT acceleration later).
-  - `GrothProofs/src/Groth16.jl`: A simplified, educational Groth16 (CRS, prove, verify) that demonstrates the flow but is intentionally not the full construction.
-
-[... original deep-dive continues ...]
-
-## BN254 Field Extensions, Tower, and Pairing: A Focused Overview
-
-This section distinguishes between (a) the math we need, (b) representation options, and (c) algorithmic choices taken here, with references.
-
-### The Math We Need
-
-- Fields and Tower
-  - Base field: Fp with BN254 prime p. See `BN254_PRIME` in `GrothCurves/src/BN254Fp2.jl` and field arithmetic in `GrothAlgebra/src/FiniteFields.jl`.
-  - Quadratic extension: Fp2 = Fp[u]/(u² + 1). Elements are a + b·u.
-    - Multiplication: (a₀ + a₁u)(b₀ + b₁u) = (a₀b₀ − a₁b₁) + (a₀b₁ + a₁b₀)u.
-    - Conjugate: \(\overline{a + bu} = a - bu\).
-    - Norm: \(N(a + bu) = a^2 + b^2\).
-    - Inverse: \((a + bu)^{-1} = (a - bu)/(a^2 + b^2)\).
-  - Fp6 = Fp2[v]/(v³ - ξ) with ξ = 9 + u; split into cubic extension over Fp2.
-  - Fp12 = Fp6[w]/(w² - v); final extension needed for GT.
-
-- Curve Groups
-  - G1: E(Fp) defined by y² = x³ + b with b = 3.
-  - G2: defined over Fp2, using the sextic twist.
-
-- Pairing
-  - Optimal ate pairing e : G1 × G2 → GT with embedding degree 12.
-  - Follows standard loop count (six bits of BN parameter u in NAF form) with Frobenius corrections.
-
-### Representation Options (semantics-preserving)
-
-- Field elements stored as small static tuples (`SVector`) to keep heap allocations down.
-- G1/G2 stored in Jacobian coordinates (X:Y:Z) with the curve parameter a = 0 simplifying formulas.
-- Fp12 stored as `Fp6_c0 + Fp6_c1 · w` with Fp6 stored as three Fp2 elements.
-
-### Algorithmic Choices (performance / implementation detail)
-
-- Fp2/Fp6/Fp12 multiplication uses Karatsuba-like decompositions and leverages nonresidue relationships to cut multiplications.
-- Miller loop uses sparse line evaluation and explicit negation steps to minimise Fp12 multiplies.
-- Final exponentiation uses Frobenius maps for the easy part and a standard BN ladder for the hard part (`exp_by_u`, `frobenius_p1/p2/p3`).
-- MSM and fixed-base tables currently live in `GrothAlgebra/src/Group.jl`; variable-base MSM now uses a Pippenger backend with a small-input Straus fallback, while fixed-base follow-up work remains on the roadmap.
-
-## Where We Are vs. What’s Left for Groth16
-
-- Groth16 pipeline (CRS, prove, verify) is educationally complete but needs FFT-backed domain alignment to match arkworks (work in progress).
-- Coset FFT path is implemented and default; dense path survives only for assertions/tests.
-- Prepared verifier matches arkworks’ prepared path (batched pairing with a single final exponentiation).
-- Proof aggregation is still outstanding.
-
-## Implementation-Focused Math Notes (with Repo Mapping)
-
-- Fp2 arithmetic (BN254, u² = −1) — `BN254Fp2.jl`
-  - \((a_0 + a_1 u)(b_0 + b_1 u) = (a_0 b_0 - a_1 b_1) + (a_0 b_1 + a_1 b_0) u)\).
-  - Conjugate \(\overline{a_0 + a_1 u} = a_0 - a_1 u\) and norm \(N(a) = a_0^2 + a_1^2\).
-- Fp6 over Fp2 via v³ = ξ (ξ = 9 + u) — `BN254Fp6_3over2.jl`
-  - Elements \(c_0 + c_1 v + c_2 v^2\) with Karatsuba cross-terms folded via ξ.
-- Fp12 over Fp6 via w² = v — `BN254Fp12_2over6.jl`
-  - Multiplication reduces `(d0 + d1w)(e0 + e1w)` using the relation w² = v.
-- G1/G2 Jacobian formulas — `BN254Curve.jl`
-  - Doubling: `M = 3X^2`, `S = 4XY^2`, etc. Mixed addition leverages affine second operand.
-- Miller loop — `BN254MillerLoop.jl`
-  - D-twist line evaluation, sparse Fp12 multiplication, Frobenius corrections.
-- Final exponentiation — `BN254FinalExp.jl`
-  - Easy part (`(f^p^6 / f)` etc.) and hard part via Frobenius + `exp_by_u` combos.
-
-## Practical Distinctions: Math vs. Representation vs. Algorithms
-
-- **Math invariants** — group laws, pairing bilinearity, field identities.
-- **Representation** — coordinate systems, tower shapes, data layout; doesn’t change correctness but impacts performance.
-- **Algorithms** — Karatsuba, sparse Fp12 ops, NAF loops, w-NAF MSM, etc.
-
-## Glossary of Notation
 
 - Fp, Fp2, Fp6, Fp12: Base and extension fields.
 - G1, G2: Curve groups used in Groth16.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,7 +38,7 @@ makedocs(
     checkdocs=:none,
     repo=Remotes.GitHub("0xpantera", "Groth.jl"),
     meta=Dict(
-        :description => "Groth.jl provides algebra, curve, and Groth16 proof tooling in Julia.",
+        :description => "Groth.jl is a Julia research platform for BN254 algebra, pairings, and Groth16.",
     ),
 )
 

--- a/docs/src/algebra.md
+++ b/docs/src/algebra.md
@@ -17,7 +17,9 @@ Depth = 2
 
 ## Key Modules
 
-- `src/FiniteFields.jl` – BigInt-backed fields with normalisation, `invmod`, and `powermod` helpers.
+- `src/FiniteFields.jl` – prime-field backends, including fixed-width
+  Montgomery `BN254Fq` / `BN254Fr`, plus canonical integer conversion and
+  generic field helpers.
 - `src/Polynomial.jl` – Degree/leading-coefficient utilities, Horner evaluation, interpolation, derivative, and FFT scaffolding.
 - `src/Group.jl` – Generic group element interface with scalar multiplication, w-NAF helpers, and MSM support.
 
@@ -29,7 +31,9 @@ Depth = 2
 
 ## Follow-ups
 
-- Evaluate FFT twiddle caching and mixed-radix support once QAP domain alignment lands.
+- Replace the remaining `BigInt` inversion escape hatch in the BN254 Montgomery
+  backend.
+- Keep prover-shaped MSM specialization tied to measured benchmark artifacts.
 
 ## Finite Fields
 

--- a/docs/src/implementation-notes.md
+++ b/docs/src/implementation-notes.md
@@ -12,16 +12,17 @@ Depth = 2
 ## Repository Snapshot
 
 - **GrothAlgebra** – prime-field arithmetic (BN254, secp256k1), polynomial
-  utilities, and generic MSM helpers. FFT helpers now guard the dense fallback
-  behind parity assertions; `interpolate_prefix_points` recovers coefficients for
-  subset domains before coset padding.
+  utilities, and generic MSM helpers. BN254 `Fq` / `Fr` now run on a
+  Montgomery backend, and the current follow-through work is focused on the
+  remaining `BigInt` escape hatches and prover-shaped specialization.
 - **GrothCurves** – BN254 tower fields, Jacobian G1/G2 arithmetic, and the
   optimal ate pairing pipeline. Sparse Fp12 placement and Frobenius corrections
   follow standard BN references; the `ProjectivePoint` abstraction keeps the
   pairing engine generic.
 - **GrothProofs** – R1CS/QAP conversion plus Groth16 setup/prove/verify.
-  Coset FFT is the default; the dense quotient remains solely as an assertion
-  until the domain alignment work completes.
+  Coset FFT is the default; the dense quotient remains solely as an assertion.
+  The latest prover work has shifted from broad backend replacement to the
+  remaining hot-path specialization tracked in the roadmap.
 - **GrothExamples / benchmarks** – notebook-first tutorials (including
   AbstractAlgebra and package-native R1CS → QAP walkthroughs), alongside JSON/PNG
   benchmark artefacts capturing prover hot paths.
@@ -43,20 +44,17 @@ Depth = 2
 - `R1CS.jl` defines reusable fixtures (multiplication, sum-of-products,
   affine-product, square-offset) and powers the randomised circuit generator.
 - `QAP.jl` records constraint points, builds power-of-two domains, and currently
-  recovers coefficients via barycentric interpolation before padding. Aligning
-  the domain layout with arkworks is the next step.
+  recovers coefficients via barycentric interpolation before padding.
 - `Groth16.jl` wires the setup, prover, and verifier paths, including the
   prepared verifier that batches pairings (`pairing_batch`) before the single
   final exponentiation.
 
 ## Follow-ups from the Roadmap
 
-- Populate every evaluation-domain slot before the IFFT so we can remove the
-  barycentric interpolation helper.
-- Prototype a second pairing engine (e.g., BLS12-381) to validate the
-  abstractions and surface any assumptions baked into the BN254 pipeline.
-- Evaluate FFT twiddle caching, mixed-radix support, and arkworks-style proof
-  aggregation once the domain-alignment work lands.
+- Replace the remaining `BigInt`-based inversion path in the BN254 backend.
+- Specialize final exponentiation and other extension-field hot paths further.
+- Rebaseline `prove_full` after each high-leverage specialization stage before
+  deciding when Stage 9 parallelism is worth doing.
 
 ## References
 

--- a/docs/src/implementation-vs-arkworks.md
+++ b/docs/src/implementation-vs-arkworks.md
@@ -26,10 +26,12 @@ Depth = 2
 
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
-| Variable-base MSM | Straus with optional endomorphism on BLS curves. | `GrothAlgebra.multi_scalar_mul` now uses a Pippenger-style variable-base backend with a small-input Straus fallback; w-NAF helpers are shared with arkworks. Endomorphism optimisations are still TODO. |
+| Variable-base MSM | Straus / Pippenger variants with endomorphism support where safe. | `GrothAlgebra.multi_scalar_mul` uses a Pippenger-style backend with a small-input Straus fallback; BN254 G1 now has a measured hybrid GLV path, and G2 has an internal GLV path that is not yet the unconditional public default. |
 | Fixed-base tables | `FixedBaseMSM` window tables. | `FixedBaseTable` plus `build_fixed_table`, `mul_fixed`, and `batch_mul` mirror the workflow; benchmarks track table build vs reuse. |
 
-**Next steps:** profile the prover with window heuristics and consider endomorphisms once the coset path stabilises.
+**Next steps:** keep MSM work tied to the real `prove_full` fixtures, pursue
+safe G2 GLV exposure, and avoid treating synthetic MSM sweeps as the sole
+tuning signal.
 
 ## Curve Abstractions & Pairing Engine
 
@@ -48,11 +50,12 @@ Depth = 2
 | Prepared verifier | `PreparedVerifyingKey` batches pairings. | `prepare_verifying_key`, `prepare_inputs`, and `verify_with_prepared` mirror the API. |
 | Aggregation | Optional `groth16::aggregate_proofs`. | Not yet ported; tracked on the roadmap. |
 
-## Upcoming Alignment Tasks
+## Current Follow-Through Tasks
 
-1. Populate every evaluation domain slot (`num_constraints + num_inputs`) before the IFFT so we can delete the barycentric interpolation helper.
-2. Mirror arkworks’ domain utilities (cached vanishing evaluations, twiddle reuse) once the layout matches.
-3. Rebaseline benchmarks after the domain alignment to ensure prover performance stays on track.
-4. Port proof aggregation only after the core prover is arkworks-aligned.
+1. Replace the remaining `BigInt`-based inversion path in the BN254 Montgomery backend.
+2. Specialize final exponentiation further around cyclotomic operations and measured BN254 structure.
+3. Reduce value churn in extension-field hot paths where the current pairing code is still less in-place than arkworks.
+4. Find a safe way to expose G2 GLV acceleration on subgroup-owned points without weakening public semantics.
+5. Rebaseline `prove_full` after each high-leverage specialization stage instead of batching changes together.
 
 Use this page as a checklist whenever behaviour changes—update the tables above as new features land.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,12 @@ CurrentModule = GrothProofs
 ```
 
 Welcome to the evolving documentation for Groth.jl. These pages will unify the
-algebra, curve, and Groth16 proof tooling that lives across the repository.
+algebra, curve, pairing, and Groth16 tooling that lives across the repository.
+
+Groth.jl is a Julia research platform for BN254 primitives and Groth16. The
+current codebase includes a Montgomery-backed BN254 field layer, extension
+tower, G1/G2 arithmetic, optimal ate pairing, and an end-to-end Groth16
+pipeline, with benchmarks and profiles tied directly to the active roadmap.
 
 ```@contents
 Pages = ["index.md"]

--- a/docs/src/proofs.md
+++ b/docs/src/proofs.md
@@ -24,11 +24,17 @@ Depth = 2
 ## Implementation Notes
 
 - Coset FFT path is the default; dense vs coset parity is asserted to guard regressions.
-- Subset domains recover coefficients via barycentric interpolation before the FFT padding step until the domain alignment work completes.
+- Subset domains currently recover coefficients via barycentric interpolation
+  before the FFT padding step.
+- The latest prover optimization work is now focused on the remaining
+  specialization buckets surfaced by the Stage 8A `prove_full` baseline rather
+  than on broad backend replacement.
 
 ## Follow-ups
 
-- Align QAP domain population with arkworks, removing the interpolation shim.
+- Replace the remaining `BigInt`-based inversion and other low-level backend
+  escape hatches that still show up in the prover and pairing profiles.
+- Keep prover-shaped MSM work tied to the deterministic `prove_full` fixtures.
 - Investigate arkworks-style proof aggregation if bandwidth becomes a constraint.
 
 ## R1CS and QAP

--- a/docs/src/rareskills-map.md
+++ b/docs/src/rareskills-map.md
@@ -25,10 +25,13 @@ graph TD
 
 - **RareSkills chapters:** `finite-fields`, `multiplicative-subgroups`, `polynomial`, `inner-product-algebra`.
 - **Groth.jl counterparts:**
-  - `GrothAlgebra/FiniteFields.jl` defines `FiniteFieldElement` (BN254, secp256k1) using BigInt normalisation.
+  - `GrothAlgebra/FiniteFields.jl` defines `FiniteFieldElement` plus the
+    current fixed-width Montgomery BN254 field backend.
   - `GrothAlgebra/Polynomial.jl` implements Horner evaluation, interpolation, derivatives, and FFT scaffolding.
   - `GrothAlgebra/Group.jl` provides curve-agnostic group operations, w-NAF helpers, and MSM support.
-- **What changes in code:** we lean on `SVector` storage, windowed MSM, and FFT-friendly evaluation domains to feed the prover efficiently.
+- **What changes in code:** we lean on fixed-width limbs, concrete extension-field
+  storage, windowed MSM, and FFT-friendly evaluation domains to feed the prover
+  efficiently.
 
 ## Curves, Towers, and Pairings
 
@@ -45,7 +48,9 @@ graph TD
 - **Groth.jl counterparts:**
   - `GrothProofs/R1CS.jl` ships multiplication, sum-of-products, affine-product, and square-offset circuits plus randomised fixtures.
   - `GrothProofs/QAP.jl` records constraint points, constructs power-of-two domains, and currently recovers coefficients via barycentric interpolation before padding for the coset FFT.
-- **What changes in code:** the prover defaults to the coset quotient path, leaving the dense path as a parity assertion until domain alignment completes.
+- **What changes in code:** the prover defaults to the coset quotient path, and
+  the dense path survives only as a parity assertion. The current performance
+  work is now focused more on prover hot paths than on broad domain rewrites.
 
 ## Groth16 Pipeline
 


### PR DESCRIPTION
## Summary
- rewrite the top-level README so it reflects the current BN254/algebra/pairing/Groth16 scope
- refresh stale overview/reference docs and remove the duplicated legacy appendix from `docs/PACKAGE_REFERENCE.md`
- fold the remaining targeted-specialization roadmap into the canonical roadmap/reference pages

## Validation
- `julia --project=docs docs/make.jl`

## Notes
- leaves unrelated local user changes (`AGENTS.md`, `PLAN.md.bk`, `docs/CRYPTOGRAPHIC_ARCHITECTURE.md`, `docs/reviews/`) untouched
- suggested repo description to apply separately: `Julia research platform for BN254 algebra, pairings, and Groth16 performance engineering.`