### PR TITLE
groth16: tune prover-shaped MSM path

### DIFF
--- a/GrothAlgebra/src/Group.jl
+++ b/GrothAlgebra/src/Group.jl
@@ -305,7 +305,8 @@ function multi_scalar_mul(points::Vector{G}, scalars::Vector{BN254Fr}) where {C,
     @inbounds for i in eachindex(scalars)
         limbs = canonical_limbs(scalars[i])
         scalar_limbs[i] = limbs
-        max_bits = max(max_bits, _limbs_bit_length(limbs))
+        bit_length = _limbs_bit_length(limbs)
+        max_bits = max(max_bits, bit_length)
     end
 
     if max_bits == 0
@@ -396,7 +397,154 @@ function _multi_scalar_mul_pippenger(points::Vector{G}, scalars::Vector{NTuple{4
     return result
 end
 
+"""
+    multi_scalar_mul_pair(points_a::Vector{G}, points_b::Vector{G}, scalars::Vector{BN254Fr})
+
+Compute two BN254Fr MSMs over the same scalar vector in one scalar scan.
+
+This is useful for Groth16 prover queries where A and B1 are both G1 MSMs over
+the witness scalars. It preserves the same result as calling
+`multi_scalar_mul` twice, while sharing scalar decoding, bit tests, and bucket
+digit extraction.
+"""
+function multi_scalar_mul_pair(points_a::Vector{G}, points_b::Vector{G}, scalars::Vector{BN254Fr}) where {C,G<:GroupElem{C}}
+    if length(points_a) != length(points_b) || length(points_a) != length(scalars)
+        throw(ArgumentError("Point and scalar vectors must have the same length"))
+    end
+
+    isempty(points_a) && throw(ArgumentError("Cannot compute multi-scalar multiplication of empty vectors"))
+
+    if length(points_a) == 1
+        return scalar_mul(points_a[1], scalars[1]), scalar_mul(points_b[1], scalars[1])
+    end
+
+    scalar_limbs = Vector{NTuple{4,UInt64}}(undef, length(scalars))
+    max_bits = 0
+    nonzero_count = 0
+    compact_scalar_count = 0
+    @inbounds for i in eachindex(scalars)
+        limbs = canonical_limbs(scalars[i])
+        scalar_limbs[i] = limbs
+        bit_length = _limbs_bit_length(limbs)
+        max_bits = max(max_bits, bit_length)
+        nonzero_count += Int(bit_length != 0)
+        compact_scalar_count += Int(bit_length <= MONT_WORD_BITS)
+    end
+
+    if max_bits == 0
+        return zero(points_a[1]), zero(points_b[1])
+    end
+
+    if length(points_a) < MSM_PIPPENGER_THRESHOLD
+        return _multi_scalar_mul_straus_pair(points_a, points_b, scalar_limbs, max_bits)
+    end
+
+    return _multi_scalar_mul_pippenger_pair(
+        points_a,
+        points_b,
+        scalar_limbs,
+        max_bits,
+        _pippenger_window(G, length(points_a), max_bits, nonzero_count, compact_scalar_count),
+    )
+end
+
+function _multi_scalar_mul_straus_pair(points_a::Vector{G}, points_b::Vector{G}, scalars::Vector{NTuple{4,UInt64}}, max_bits::Int) where {C,G<:GroupElem{C}}
+    if max_bits == 0
+        return zero(points_a[1]), zero(points_b[1])
+    end
+
+    result_a = zero(points_a[1])
+    result_b = zero(points_b[1])
+
+    for bit_pos in (max_bits - 1):-1:0
+        result_a = result_a + result_a
+        result_b = result_b + result_b
+
+        @inbounds for i in eachindex(points_a, points_b, scalars)
+            if _limbs_testbit(scalars[i], bit_pos)
+                result_a = result_a + points_a[i]
+                result_b = result_b + points_b[i]
+            end
+        end
+    end
+
+    return result_a, result_b
+end
+
+function _multi_scalar_mul_pippenger_pair(points_a::Vector{G}, points_b::Vector{G}, scalars::Vector{NTuple{4,UInt64}}, max_bits::Int, window::Int) where {C,G<:GroupElem{C}}
+    normalized_points_a = Vector{G}(undef, length(points_a))
+    normalized_points_b = Vector{G}(undef, length(points_b))
+    normalized_scalars = Vector{NTuple{4,UInt64}}(undef, length(scalars))
+    nonzero_count = 0
+
+    @inbounds for i in eachindex(points_a, points_b, scalars)
+        limbs = scalars[i]
+        _limbs_iszero(limbs) && continue
+        nonzero_count += 1
+        normalized_points_a[nonzero_count] = points_a[i]
+        normalized_points_b[nonzero_count] = points_b[i]
+        normalized_scalars[nonzero_count] = limbs
+    end
+
+    if nonzero_count == 0
+        return zero(points_a[1]), zero(points_b[1])
+    elseif nonzero_count == 1
+        scalar = _bn254fr_from_canonical_limbs(normalized_scalars[1])
+        return scalar_mul(normalized_points_a[1], scalar), scalar_mul(normalized_points_b[1], scalar)
+    elseif nonzero_count < MSM_PIPPENGER_THRESHOLD
+        resize!(normalized_points_a, nonzero_count)
+        resize!(normalized_points_b, nonzero_count)
+        resize!(normalized_scalars, nonzero_count)
+        return _multi_scalar_mul_straus_pair(normalized_points_a, normalized_points_b, normalized_scalars, max_bits)
+    end
+
+    resize!(normalized_points_a, nonzero_count)
+    resize!(normalized_points_b, nonzero_count)
+    resize!(normalized_scalars, nonzero_count)
+
+    bucket_count = (1 << window) - 1
+    num_windows = cld(max_bits, window)
+    zero_a = zero(points_a[1])
+    zero_b = zero(points_b[1])
+    buckets_a = fill(zero_a, bucket_count)
+    buckets_b = fill(zero_b, bucket_count)
+    result_a = zero_a
+    result_b = zero_b
+
+    for window_index in (num_windows - 1):-1:0
+        for _ in 1:window
+            result_a = result_a + result_a
+            result_b = result_b + result_b
+        end
+
+        fill!(buckets_a, zero_a)
+        fill!(buckets_b, zero_b)
+        shift = window_index * window
+
+        @inbounds for i in eachindex(normalized_points_a, normalized_points_b, normalized_scalars)
+            digit = _limbs_window_digit(normalized_scalars[i], shift, window)
+            if digit != 0
+                buckets_a[digit] = buckets_a[digit] + normalized_points_a[i]
+                buckets_b[digit] = buckets_b[digit] + normalized_points_b[i]
+            end
+        end
+
+        running_sum_a = zero_a
+        running_sum_b = zero_b
+        @inbounds for bucket_index in bucket_count:-1:1
+            running_sum_a = running_sum_a + buckets_a[bucket_index]
+            running_sum_b = running_sum_b + buckets_b[bucket_index]
+            result_a = result_a + running_sum_a
+            result_b = result_b + running_sum_b
+        end
+    end
+
+    return result_a, result_b
+end
+
 @inline _pippenger_window(::Type{<:GroupElem}, size::Int) = _default_pippenger_window(size)
+@inline _pippenger_window(::Type{G}, size::Int, ::Int, ::Int, ::Int) where {G<:GroupElem} =
+    _pippenger_window(G, size)
 
 @inline function _default_pippenger_window(size::Int)
     if size < 32

--- a/GrothCurves/src/BN254Curve.jl
+++ b/GrothCurves/src/BN254Curve.jl
@@ -48,6 +48,16 @@ function _pippenger_window(::Type{G1Point}, size::Int)
     return GrothAlgebra._default_pippenger_window(size)
 end
 
+# The fused Groth16 A/B1 query MSM scans one witness scalar stream for two G1
+# point tables. At the current prover fixture sizes, mixed compact/full-width
+# witness scalars prefer a narrower bucket window than dense H/L MSMs.
+function _pippenger_window(::Type{G1Point}, size::Int, ::Int, ::Int, compact_scalar_count::Int)
+    if 8 <= size <= 32 && compact_scalar_count * 2 >= size
+        return 2
+    end
+    return _pippenger_window(G1Point, size)
+end
+
 function _pippenger_window(::Type{G2Point}, size::Int)
     if size <= 32
         return 2

--- a/GrothCurves/test/test_bn254_curve.jl
+++ b/GrothCurves/test/test_bn254_curve.jl
@@ -392,6 +392,28 @@ glv_component_bits(component::Tuple{Bool,BigInt}) = iszero(component[2]) ? 0 : n
 
             @test multi_scalar_mul(g1_points, msm_scalars) == multi_scalar_mul(g1_points, msm_bigints)
             @test multi_scalar_mul(g2_points, msm_scalars) == multi_scalar_mul(g2_points, msm_bigints)
+
+            prover_points = [scalar_mul(g1, i + 20) for i in 1:8]
+            prover_scalars = [
+                bn254_fr(1),
+                bn254_fr(2),
+                bn254_fr(3),
+                bn254_fr(4),
+                bn254_fr(benchmark_scalar(701)),
+                bn254_fr(benchmark_scalar(702)),
+                bn254_fr(benchmark_scalar(703)),
+                bn254_fr(benchmark_scalar(704)),
+            ]
+            prover_bigints = map(x -> convert(BigInt, x), prover_scalars)
+
+            @test GrothAlgebra._pippenger_window(G1Point, 8, 254, 8, 4) == 2
+            @test GrothAlgebra._pippenger_window(G1Point, 8, 254, 8, 3) == 3
+            @test multi_scalar_mul(prover_points, prover_scalars) == multi_scalar_mul(prover_points, prover_bigints)
+
+            prover_points_b = [scalar_mul(g1, i + 40) for i in 1:8]
+            pair_a, pair_b = GrothAlgebra.multi_scalar_mul_pair(prover_points, prover_points_b, prover_scalars)
+            @test pair_a == multi_scalar_mul(prover_points, prover_scalars)
+            @test pair_b == multi_scalar_mul(prover_points_b, prover_scalars)
         end
     end
     

--- a/GrothProofs/src/Groth16.jl
+++ b/GrothProofs/src/Groth16.jl
@@ -235,9 +235,8 @@ function prove_full(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng::Abstr
 
     # Accumulators for queries via MSM (fallbacks to scalar loops for tiny sizes)
     scalars = w_vals[1:m]
-    A_acc_g1 = GrothAlgebra.multi_scalar_mul(pk.A_query_g1, scalars)
+    A_acc_g1, B_acc_g1 = GrothAlgebra.multi_scalar_mul_pair(pk.A_query_g1, pk.B_query_g1, scalars)
     B_acc_g2 = GrothAlgebra.multi_scalar_mul(pk.B_query_g2, scalars)
-    B_acc_g1 = GrothAlgebra.multi_scalar_mul(pk.B_query_g1, scalars)
 
     # A and B
     A1_g1 = pk.alpha_g1 + A_acc_g1

--- a/GrothProofs/src/Groth16.jl
+++ b/GrothProofs/src/Groth16.jl
@@ -260,11 +260,11 @@ function prove_full(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng::Abstr
         L = zero(G1Point)
     end
 
-    # Cross terms in C (arkworks style): C = s*g_a + r*g1_b - r*s*δ + L + H
-    # where g_a = A (includes r*δ), and g1_b = (β + Σ v_i) + s*δ in G1
+    # Cross terms in C. This is algebraically equivalent to
+    # `s*A + r*(B1_g1 + s*δ) - r*s*δ + L + H`, but avoids one G1 scalar
+    # multiplication by expanding A = A1_g1 + r*δ.
     rs_delta = scalar_mul(pk.delta_g1, r * s)
-    g1_b_full = B1_g1 + scalar_mul(pk.delta_g1, s)
-    C = H + L + scalar_mul(g1_b_full, r) + scalar_mul(A, s) - rs_delta
+    C = H + L + scalar_mul(B1_g1, r) + scalar_mul(A1_g1, s) + rs_delta
 
     return Groth16Proof(A, B, C)
 end

--- a/benchmarks/prove_full_common.jl
+++ b/benchmarks/prove_full_common.jl
@@ -259,8 +259,7 @@ function l_msm(pk::ProvingKey, witness::Witness)
     return GrothAlgebra.multi_scalar_mul(pk.L_query_g1, priv_scalars)
 end
 
-function assemble_c(pk::ProvingKey, A, B1_g1, H, L, r, s)
+function assemble_c(pk::ProvingKey, A1_g1, B1_g1, H, L, r, s)
     rs_delta = scalar_mul(pk.delta_g1, r * s)
-    g1_b_full = B1_g1 + scalar_mul(pk.delta_g1, s)
-    return H + L + scalar_mul(g1_b_full, r) + scalar_mul(A, s) - rs_delta
+    return H + L + scalar_mul(B1_g1, r) + scalar_mul(A1_g1, s) + rs_delta
 end

--- a/benchmarks/prove_full_common.jl
+++ b/benchmarks/prove_full_common.jl
@@ -8,6 +8,7 @@ const PROVE_FULL_PHASE_ORDER = [
     "witness_to_scalars",
     "msm_a_g1",
     "msm_b_g1",
+    "msm_a_b1_g1",
     "msm_b_g2",
     "compute_h_total",
     "h_poly_assembly",
@@ -227,9 +228,10 @@ function sample_prove_randomizers(fixture)
 end
 
 function prove_query_accumulators(pk::ProvingKey, scalars::AbstractVector)
+    A_acc_g1, B_acc_g1 = GrothAlgebra.multi_scalar_mul_pair(pk.A_query_g1, pk.B_query_g1, scalars)
     return (
-        A_acc_g1 = GrothAlgebra.multi_scalar_mul(pk.A_query_g1, scalars),
-        B_acc_g1 = GrothAlgebra.multi_scalar_mul(pk.B_query_g1, scalars),
+        A_acc_g1 = A_acc_g1,
+        B_acc_g1 = B_acc_g1,
         B_acc_g2 = GrothAlgebra.multi_scalar_mul(pk.B_query_g2, scalars),
     )
 end

--- a/benchmarks/run.jl
+++ b/benchmarks/run.jl
@@ -1375,15 +1375,19 @@ function bench_prove_full(results)
         scalars = witness_to_scalars(witness)
         _ = GrothAlgebra.multi_scalar_mul(pk.A_query_g1, scalars)
         _ = GrothAlgebra.multi_scalar_mul(pk.B_query_g1, scalars)
+        _ = GrothAlgebra.multi_scalar_mul_pair(pk.A_query_g1, pk.B_query_g1, scalars)
         _ = GrothAlgebra.multi_scalar_mul(pk.B_query_g2, scalars)
         tr_msm_a = @benchmark GrothAlgebra.multi_scalar_mul($pk.A_query_g1, $scalars) seconds = 1 samples = 10
         tr_msm_b1 = @benchmark GrothAlgebra.multi_scalar_mul($pk.B_query_g1, $scalars) seconds = 1 samples = 10
+        tr_msm_a_b1 = @benchmark GrothAlgebra.multi_scalar_mul_pair($pk.A_query_g1, $pk.B_query_g1, $scalars) seconds = 1 samples = 10
         tr_msm_b2 = @benchmark GrothAlgebra.multi_scalar_mul($pk.B_query_g2, $scalars) seconds = 1 samples = 10
         print_stats("prove_full[$(name)] A_msm", tr_msm_a)
         print_stats("prove_full[$(name)] B1_msm", tr_msm_b1)
+        print_stats("prove_full[$(name)] A+B1_msm", tr_msm_a_b1)
         print_stats("prove_full[$(name)] B2_msm", tr_msm_b2)
         record_fixture_trial!(results, :prove_full, name, "msm_a_g1", tr_msm_a)
         record_fixture_trial!(results, :prove_full, name, "msm_b_g1", tr_msm_b1)
+        record_fixture_trial!(results, :prove_full, name, "msm_a_b1_g1", tr_msm_a_b1)
         record_fixture_trial!(results, :prove_full, name, "msm_b_g2", tr_msm_b2)
 
         _ = compute_h_polynomial(qap, witness)

--- a/benchmarks/run.jl
+++ b/benchmarks/run.jl
@@ -1435,8 +1435,8 @@ function bench_prove_full(results)
         ab_terms = assemble_ab_terms(pk, accum.A_acc_g1, accum.B_acc_g1, accum.B_acc_g2, r_rand, s_rand)
         H = h_msm(pk, h_poly)
         L = l_msm(pk, witness)
-        _ = assemble_c(pk, ab_terms.A, ab_terms.B1_g1, H, L, r_rand, s_rand)
-        tr_final_c = @benchmark assemble_c($pk, $(ab_terms.A), $(ab_terms.B1_g1), $H, $L, $r_rand, $s_rand) seconds = 1 samples = 10
+        _ = assemble_c(pk, ab_terms.A1_g1, ab_terms.B1_g1, H, L, r_rand, s_rand)
+        tr_final_c = @benchmark assemble_c($pk, $(ab_terms.A1_g1), $(ab_terms.B1_g1), $H, $L, $r_rand, $s_rand) seconds = 1 samples = 10
         print_stats("prove_full[$(name)] C_final", tr_final_c)
         record_fixture_trial!(results, :prove_full, name, "final_c", tr_final_c)
     end


### PR DESCRIPTION
## Summary
- add a fused BN254Fr two-output MSM helper for Groth16 A/B1 query accumulation
- use the fused A/B1 path in prove_full and benchmark it explicitly
- simplify prover C assembly to the equivalent H + L + r*B1 + s*A1 + r*s*delta form, avoiding one G1 scalar multiplication

## Benchmarks
Baseline artifact: benchmarks/artifacts/2026-05-11_112844/ (ignored locally)
After artifact: benchmarks/artifacts/2026-05-11_123425/ (ignored locally)

Generated 24-constraint fixture medians:
- prove_full: 28.386 ms -> 26.287 ms
- C_final: 2.994 ms -> 2.069 ms
- A+B1_msm after: 4.745 ms

Notes:
- slice allocation checks showed H/L slice copies were not meaningful compared with MSM-internal allocations
- same-session A/B verified the expanded C formula produces the exact same C and valid proofs
- final benchmark was run on Julia 1.12.6; the earlier same-day baseline artifact was on Julia 1.12.5

## Validation
- Pkg.test("GrothProofs")
- include("scripts/test_all.jl") passes 4/4 suites
- benchmarks/run.jl --profile=stage8
- benchmarks/plot.jl 2026-05-11_123425