### PR TITLE
groth16: align qap domain layout

### DIFF
--- a/GrothExamples/src/r1cs_qap_groth_pluto.jl
+++ b/GrothExamples/src/r1cs_qap_groth_pluto.jl
@@ -136,7 +136,9 @@ qap = r1cs_to_qap(r1cs)
 begin
     (
         num_constraints=qap.num_constraints,
+        num_public=qap.num_public,
         num_vars=qap.num_vars,
+        requested_domain_slots=qap.num_constraints + qap.num_public,
         points=[BigInt(p.value) for p in qap.points],
         domain_size=qap.domain.size,
         coset_size=qap.coset_domain.size,
@@ -149,7 +151,7 @@ end
 md"""
 ### Column-wise interpolation spot check
 
-`u[j], v[j], w[j]` are interpolated column polynomials. Evaluating at constraint points recovers matrix entries.
+`u[j], v[j], w[j]` are interpolated column polynomials. Evaluating at constraint points recovers matrix entries. The full domain follows the arkworks layout: constraint rows first, public-input selector rows next, and zero padding last.
 """
 
 # ╔═╡ 7f9fca90-1111-4f2e-93ec-52b9694d0015
@@ -171,6 +173,22 @@ begin
 end
 
 # ╔═╡ 7f9fca90-1111-4f2e-93ec-52b9694d0016
+begin
+    ω = qap.domain.generator
+    selector_rows = map(1:qap.num_public) do public_index
+        pt = ω^(qap.num_constraints + public_index - 1)
+        (
+            public_variable=labels[public_index],
+            point=BigInt(pt.value),
+            u_values=[BigInt(evaluate(qap.u[j], pt).value) for j in 1:qap.num_public],
+            v_zero=all(iszero(evaluate(qap.v[j], pt)) for j in 1:qap.num_vars),
+            w_zero=all(iszero(evaluate(qap.w[j], pt)) for j in 1:qap.num_vars),
+        )
+    end
+    selector_rows
+end
+
+# ╔═╡ 7f9fca90-1111-4f2e-93ec-52b9694d1016
 md"""
 ## Build `A(x)`, `B(x)`, `C(x)` from witness
 """
@@ -196,7 +214,10 @@ end
 md"""
 ## Constraint polynomial `P(x)`
 
-For a valid witness, `P(x) = A(x)B(x) - C(x)` vanishes on all constraint points.
+For a valid witness, `P(x) = A(x)B(x) - C(x)` vanishes on the full QAP domain:
+active constraint points vanish by R1CS satisfaction, public-input selector rows
+vanish because `B` and `C` are zero there, and padding rows vanish because all
+three polynomial families are zero there.
 """
 
 # ╔═╡ 7f9fca90-1111-4f2e-93ec-52b9694d0019
@@ -307,7 +328,8 @@ For the valid witness, divisibility holds; for the bad witness, it breaks.
 # ╠═7f9fca90-1111-4f2e-93ec-52b9694d0013
 # ╟─7f9fca90-1111-4f2e-93ec-52b9694d0014
 # ╠═7f9fca90-1111-4f2e-93ec-52b9694d0015
-# ╟─7f9fca90-1111-4f2e-93ec-52b9694d0016
+# ╠═7f9fca90-1111-4f2e-93ec-52b9694d0016
+# ╟─7f9fca90-1111-4f2e-93ec-52b9694d1016
 # ╠═7f9fca90-1111-4f2e-93ec-52b9694d0017
 # ╟─7f9fca90-1111-4f2e-93ec-52b9694d0018
 # ╠═7f9fca90-1111-4f2e-93ec-52b9694d0019

--- a/GrothProofs/src/Groth16.jl
+++ b/GrothProofs/src/Groth16.jl
@@ -143,9 +143,9 @@ function setup_full(qap::QAP{F}; rng::AbstractRNG=Random.GLOBAL_RNG, engine::Abs
     # Target polynomial at τ
     t_tau = evaluate(qap.t, τ)
 
-    # τ^k powers for H query (match arkworks m_raw - 1 ≈ num_constraints + num_vars - 1)
-    # This supports h(τ) expansion: Σ h_k τ^k
-    max_k = qap.num_constraints + qap.num_vars - 1
+    # τ^k powers for H query. Since t has degree N over the full domain and
+    # U,V,W have degree at most N-1, the quotient H has degree at most N-2.
+    max_k = qap.domain.size - 1
     tau_powers = Vector{F}(undef, max_k)
     tau_powers[1] = one(F)
     for k in 2:max_k

--- a/GrothProofs/src/QAP.jl
+++ b/GrothProofs/src/QAP.jl
@@ -23,13 +23,13 @@ struct QAP{F}
     num_public::Int
     # Evaluation domain (power-of-two roots of unity)
     domain::EvaluationDomain{F}
-    # Active constraint points (subset of the domain)
+    # Active constraint points (prefix subset of the domain)
     points::Vector{F}
     # Coset domain used for FFT-based evaluation
     coset_domain::EvaluationDomain{F}
     # Reciprocal evaluations of the vanishing polynomial on the coset domain
     vanishing_coset_inv::Vector{F}
-    # Target polynomial ``t(x) = \\prod_i (x - \\omega_i)``
+    # Target polynomial ``t(x) = x^N - 1`` for the full evaluation domain.
     t::Polynomial{F}
     # Polynomials for each variable
     u::Vector{Polynomial{F}}  # Left polynomials (from L matrix)
@@ -37,36 +37,11 @@ struct QAP{F}
     w::Vector{Polynomial{F}}  # Output polynomials (from O matrix)
 end
 
-function interpolate_prefix_points(samples::Vector{F}, ω::F, n::Int) where F
-    xs = Vector{F}(undef, n)
-    xs[1] = one(F)
-    for i in 2:n
-        xs[i] = xs[i-1] * ω
-    end
-
-    result = zero(Polynomial{F})
-    for i in 1:n
-        xi = xs[i]
-        numerator = Polynomial{F}([one(F)])
-        denom = one(F)
-        for j in 1:n
-            if j == i
-                continue
-            end
-            xj = xs[j]
-            numerator *= Polynomial{F}([-xj, one(F)])
-            denom *= (xi - xj)
-        end
-        scale = samples[i] * inv(denom)
-        result += scale * numerator
-    end
-    return result
-end
-
 """
     get_roots_of_unity(n::Int, ::Type{F}) where F
 
-Construct a power-of-two evaluation domain and return the first `n` points.
+Construct a power-of-two evaluation domain and return the first `n` domain
+points.
 """
 function get_roots_of_unity(n::Int, ::Type{F}) where F
     n > 0 || throw(ArgumentError("Number of roots must be positive"))
@@ -95,57 +70,48 @@ Convert an R1CS to QAP form using Lagrange interpolation.
 function r1cs_to_qap(r1cs::R1CS{F}) where F
     n = r1cs.num_constraints
     m = r1cs.num_vars
+    domain_slots = n + r1cs.num_public
 
-    # Get evaluation domain
-    points, domain = get_roots_of_unity(n, F)
+    # Match arkworks' domain shape: active constraints followed by public-input
+    # selector slots, rounded up to a power of two.
+    domain_points, domain = get_roots_of_unity(domain_slots, F)
+    points = domain_points[1:n]
     coset_domain = get_coset(domain, default_coset_offset(F))
 
-    # Compute target polynomial t(x) = ∏(x - ωⁱ)
-    t = Polynomial{F}([one(F)])  # Start with polynomial 1
-    for ω in points
-        # Multiply by (x - ω)
-        factor = Polynomial{F}([-ω, one(F)])
-        t = t * factor
-    end
+    # Full-domain vanishing polynomial t(x) = x^N - 1.
+    t_coeffs = fill(zero(F), domain.size + 1)
+    t_coeffs[1] = -one(F)
+    t_coeffs[end] = one(F)
+    t = Polynomial{F}(t_coeffs)
 
     # Initialize polynomial arrays
     u = Vector{Polynomial{F}}(undef, m)
     v = Vector{Polynomial{F}}(undef, m)
     w = Vector{Polynomial{F}}(undef, m)
 
-    is_full_domain = n == domain.size
     # For each variable, interpolate its polynomial from the constraint values
     for j in 1:m
-        u_samples = [r1cs.L[i, j] for i in 1:n]
-        v_samples = [r1cs.R[i, j] for i in 1:n]
-        w_samples = [r1cs.O[i, j] for i in 1:n]
+        u_samples = fill(zero(F), domain.size)
+        v_samples = fill(zero(F), domain.size)
+        w_samples = fill(zero(F), domain.size)
 
-        if is_full_domain
-            u[j] = interpolate_fft(domain, u_samples)
-            v[j] = interpolate_fft(domain, v_samples)
-            w[j] = interpolate_fft(domain, w_samples)
-        else
-            coeff_u = interpolate_prefix_points(u_samples, domain.generator, n)
-            coeff_v = interpolate_prefix_points(v_samples, domain.generator, n)
-            coeff_w = interpolate_prefix_points(w_samples, domain.generator, n)
-            u[j] = coeff_u
-            v[j] = coeff_v
-            w[j] = coeff_w
+        @inbounds for i in 1:n
+            u_samples[i] = r1cs.L[i, j]
+            v_samples[i] = r1cs.R[i, j]
+            w_samples[i] = r1cs.O[i, j]
         end
+        if j <= r1cs.num_public
+            u_samples[n + j] = one(F)
+        end
+
+        u[j] = interpolate_fft(domain, u_samples)
+        v[j] = interpolate_fft(domain, v_samples)
+        w[j] = interpolate_fft(domain, w_samples)
     end
 
-    if n == domain.size
-        coset_vanishing = coset_offset_pow_size(coset_domain) - one(F)
-        iszero(coset_vanishing) && error("Coset vanishing polynomial evaluates to zero; choose a different offset")
-        vanishing_coset_inv = fill(inv(coset_vanishing), coset_domain.size)
-    else
-        t_coset = fft(t.coeffs, coset_domain)
-        vanishing_coset_inv = Vector{F}(undef, length(t_coset))
-        for i in eachindex(t_coset)
-            iszero(t_coset[i]) && error("Coset evaluation of t(x) hit zero; choose a different offset")
-            vanishing_coset_inv[i] = inv(t_coset[i])
-        end
-    end
+    coset_vanishing = coset_offset_pow_size(coset_domain) - one(F)
+    iszero(coset_vanishing) && error("Coset vanishing polynomial evaluates to zero; choose a different offset")
+    vanishing_coset_inv = fill(inv(coset_vanishing), coset_domain.size)
 
     return QAP{F}(m, n, r1cs.num_public, domain, points, coset_domain, vanishing_coset_inv, t, u, v, w)
 end

--- a/GrothProofs/test/runtests.jl
+++ b/GrothProofs/test/runtests.jl
@@ -1,12 +1,82 @@
 using GrothProofs
-using GrothAlgebra: bn254_fr, evaluate
+using GrothAlgebra: bn254_fr, evaluate, degree
 using Test
 using Random
 
 include("random_circuits.jl")
 
+function next_power_of_two(n::Int)
+    size = 1
+    while size < n
+        size <<= 1
+    end
+    return size
+end
+
 function public_inputs_for(r1cs::R1CS, witness::Witness)
     return r1cs.num_public > 1 ? witness.values[2:r1cs.num_public] : eltype(witness.values)[]
+end
+
+function combined_qap_polynomials(qap::QAP, witness::Witness)
+    u_poly = zero(qap.u[1])
+    v_poly = zero(qap.v[1])
+    w_poly = zero(qap.w[1])
+    for i in 1:qap.num_vars
+        u_poly = u_poly + witness.values[i] * qap.u[i]
+        v_poly = v_poly + witness.values[i] * qap.v[i]
+        w_poly = w_poly + witness.values[i] * qap.w[i]
+    end
+    return u_poly, v_poly, w_poly
+end
+
+@testset "QAP full-domain alignment" begin
+    for builder in (
+        create_r1cs_example_multiplication,
+        create_r1cs_example_sum_of_products,
+        create_r1cs_example_affine_product,
+        create_r1cs_example_square_offset,
+    )
+        r1cs = builder()
+        qap = r1cs_to_qap(r1cs)
+        expected_domain_size = next_power_of_two(r1cs.num_constraints + r1cs.num_public)
+
+        @test qap.domain.size == expected_domain_size
+        @test length(qap.points) == r1cs.num_constraints
+        @test degree(qap.t) == qap.domain.size
+        @test qap.t.coeffs[1] == -one(eltype(qap.t.coeffs))
+        @test qap.t.coeffs[end] == one(eltype(qap.t.coeffs))
+        @test all(iszero, qap.t.coeffs[2:end-1])
+
+        F = eltype(qap.t.coeffs)
+        for i in 1:r1cs.num_constraints
+            x = qap.points[i]
+            for j in 1:r1cs.num_vars
+                @test evaluate(qap.u[j], x) == r1cs.L[i, j]
+                @test evaluate(qap.v[j], x) == r1cs.R[i, j]
+                @test evaluate(qap.w[j], x) == r1cs.O[i, j]
+            end
+        end
+
+        point = one(eltype(qap.points))
+        for i in 1:qap.domain.size
+            if r1cs.num_constraints < i <= r1cs.num_constraints + r1cs.num_public
+                public_index = i - r1cs.num_constraints
+                for j in 1:r1cs.num_vars
+                    @test evaluate(qap.u[j], point) == (j == public_index ? one(F) : zero(F))
+                    @test iszero(evaluate(qap.v[j], point))
+                    @test iszero(evaluate(qap.w[j], point))
+                end
+            elseif i > r1cs.num_constraints + r1cs.num_public
+                for j in 1:r1cs.num_vars
+                    @test iszero(evaluate(qap.u[j], point))
+                    @test iszero(evaluate(qap.v[j], point))
+                    @test iszero(evaluate(qap.w[j], point))
+                end
+            end
+            @test iszero(evaluate(qap.t, point))
+            point *= qap.domain.generator
+        end
+    end
 end
 
 @testset "Groth16 full pipeline" begin
@@ -265,7 +335,6 @@ end
 end
 
 @testset "QAP divisibility spot-checks" begin
-    # Use both circuits to check U*V - W equals h*t at a few random points
     for builder in (
         create_r1cs_example_multiplication,
         create_r1cs_example_sum_of_products,
@@ -284,22 +353,14 @@ end
             create_witness_affine_product(2, 3, 5, 7) :
             create_witness_square_offset(2, 3, 5)
 
-        # Build combined polynomials
-        u_poly = zero(qap.u[1])
-        v_poly = zero(qap.v[1])
-        w_poly = zero(qap.w[1])
-        for i in 1:qap.num_vars
-            u_poly = u_poly + w.values[i] * qap.u[i]
-            v_poly = v_poly + w.values[i] * qap.v[i]
-            w_poly = w_poly + w.values[i] * qap.w[i]
-        end
+        u_poly, v_poly, w_poly = combined_qap_polynomials(qap, w)
         h_dense = compute_h_polynomial(qap, w; use_coset=false)
         h_coset = compute_h_polynomial(qap, w; use_coset=true)
         @test h_coset == h_dense
         h_poly = h_coset
         t_poly = qap.t
 
-        # Choose a few points outside the domain [1..n]
+        # Choose a few points outside the active constraint index range.
         pts = [bn254_fr(qap.num_constraints + k) for k in (1, 2, 3)]
         for x in pts
             lhs = evaluate(u_poly, x) * evaluate(v_poly, x) - evaluate(w_poly, x)
@@ -315,7 +376,7 @@ end
 @testset "QAP coset vanishing cases" begin
     r1cs_power = create_r1cs_example_square_offset()
     qap_power = r1cs_to_qap(r1cs_power)
-    @test qap_power.num_constraints == qap_power.domain.size
+    @test qap_power.domain.size == next_power_of_two(r1cs_power.num_constraints + r1cs_power.num_public)
     witness_power = create_witness_square_offset(2, 3, 5)
     h_dense_power = compute_h_polynomial(qap_power, witness_power; use_coset=false)
     h_coset_power = compute_h_polynomial(qap_power, witness_power; use_coset=true)
@@ -323,6 +384,7 @@ end
 
     r1cs_subset = create_r1cs_example_multiplication()
     qap_subset = r1cs_to_qap(r1cs_subset)
+    @test qap_subset.domain.size == next_power_of_two(r1cs_subset.num_constraints + r1cs_subset.num_public)
     @test qap_subset.num_constraints < qap_subset.domain.size
     witness_subset = create_witness_multiplication(3, 5, 7, 11)
     h_dense_subset = compute_h_polynomial(qap_subset, witness_subset; use_coset=false)

--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ The project has moved well beyond a minimal Groth16 demo.
   backend is now Montgomery-based.
 - Primitive benchmarks currently beat `py_ecc` across the tracked BN254 suite.
 - The gap to arkworks has narrowed substantially, but arkworks is still ahead.
-- The current larger deterministic `prove_full` baseline is `28.873 ms` in
-  [benchmarks/artifacts/2026-04-01_223859](./benchmarks/artifacts/2026-04-01_223859),
+- QAP conversion now follows the arkworks domain shape: constraints first,
+  public-input selector rows next, and zero padding to the next power of two.
+- The current larger deterministic `prove_full` baseline after QAP domain
+  alignment is `29.989 ms` in
+  [benchmarks/artifacts/2026-05-11_130524](./benchmarks/artifacts/2026-05-11_130524),
   down from the original `136.187 ms` baseline captured at the start of the
   performance investigation.
 - The active roadmap has shifted from broad backend replacement to targeted

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -321,6 +321,36 @@ The key profiler result is that the Stage 8A
 elsewhere, but the hot prover scalar conversions identified in Stage 8 have now
 been removed from the main `prove_full` path.
 
+## QAP Domain Alignment Snapshot (2026-05-11)
+
+- Stage 8 run:
+  `artifacts/2026-05-11_130524/results/benchmark_results.json`
+- Plots:
+  `artifacts/2026-05-11_130524/plots/`
+
+This run uses the arkworks-shaped QAP domain: active constraints first,
+public-input selector rows next, and zero padding to the next power of two. The
+fixtures prove once and assert `verify_full` before timing.
+
+- `sum_of_products_small`
+  - constraints/public/domain: `3 / 6 / 16`
+  - `prove_full` end-to-end: `11.298 ms`
+  - `compute_h_total`: `0.360 ms`
+  - `h_msm`: `5.702 ms`
+  - `final_c`: `2.222 ms`
+- `generated_24_constraints`
+  - constraints/public/domain: `24 / 8 / 32`
+  - `prove_full` end-to-end: `29.989 ms`
+  - `compute_h_total`: `1.723 ms`
+  - `h_msm`: `9.168 ms`
+  - `l_msm`: `4.028 ms`
+  - `final_c`: `2.211 ms`
+
+The small fixture now has a larger QAP domain because `3 constraints + 6 public`
+rounds up to `16`; treat it as a correctness-and-continuity fixture, not as a
+like-for-like timing comparison with the old constraint-only layout. The
+generated fixture remains the better continuity signal for prover-shaped tuning.
+
 Generate a full report (run -> plot -> compare) for latest run:
 
 ```

--- a/docs/Implementation_vs_Arkworks.md
+++ b/docs/Implementation_vs_Arkworks.md
@@ -8,16 +8,14 @@ intentionally diverge from their design.
 
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
-| Domain sizing | `EvaluationDomain::new(num_constraints + num_inputs)` ensures every slot is populated before an IFFT | Currently: minimal power-of-two ≥ `num_constraints`; subset circuits pad coefficients after barycentric interpolation. **Next step:** match arkworks by filling every slot so we can drop the barycentric shim |
+| Domain sizing | `EvaluationDomain::new(num_constraints + num_inputs)` ensures every slot is populated before an IFFT | Matches arkworks' shape: constraints first, public-input selector rows next, then zero padding to the next power of two |
 | Coset shift | `EvaluationDomain::get_coset(F::GENERATOR)` with tracked offset/inverses | `get_coset(domain, default_coset_offset)` tracks offset, inverse, and `offset_pow_size` |
-| Vanishing on coset | `domain.evaluate_vanishing_polynomial(g)` with cached powers | We FFT `t(x)` on the coset; for full domains we use closed form `g^n - 1`. After we align domains we can mirror arkworks’ cached evaluation |
+| Vanishing on coset | `domain.evaluate_vanishing_polynomial(g)` with cached powers | Uses the full-domain closed form `g^n - 1`, cached as a constant inverse over the shifted coset |
 
 Aug 2025 refactor summary:
 - Coset path is default (`compute_h_polynomial` asserts coset/dense equality).
-- Subset domains temporarily recover coefficients via barycentric interpolation
-  before padding in coefficient space.
-- Planned alignment: populate the entire domain as arkworks does so the FFT/IFFT
-  pair is used directly with no coefficient recovery helper.
+- QAP conversion feeds full-domain evaluation vectors to IFFT directly, so no
+  subset coefficient recovery helper is needed for the Groth16 path.
 
 ## Multi-Scalar Multiplication (MSM) & Precomputation
 
@@ -41,8 +39,8 @@ prover path.
 
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
-| R1CS → QAP | Domain filled completely, IFFT → FFT on coset | Same structure; subset handling currently requires barycentric recovery (to be removed when we align domains) |
-| Prover | Coset FFT path by default, dense path available for debugging | Coset path now default, dense used only for assertions; matches arkworks once domain alignment lands |
+| R1CS → QAP | Domain filled completely, IFFT → FFT on coset | Same structure; constraints, public-input selector slots, and zero padding are all explicit before IFFT |
+| Prover | Coset FFT path by default, dense path available for debugging | Coset path now default, dense used only for assertions |
 | Prepared verifier | `PreparedVerifyingKey` with batched pairing | `prepare_verifying_key`, `prepare_inputs`, `verify_with_prepared` mirror arkworks and use the pairing engine |
 | Aggregation | `groth16::aggregate_proofs` available | Not yet ported; on roadmap |
 
@@ -55,12 +53,11 @@ prover path.
 
 ## Upcoming Alignment Tasks
 
-1. Populate the entire evaluation domain (constraints + inputs) before calling
-   IFFT, eliminating the barycentric interpolation helper.
-2. Mirror arkworks’ domain helpers (vanishing evaluations, cached twiddles) once
-   the layout matches.
-3. Re-run benchmarks after domain alignment to ensure performance remains stable.
-4. Port proof aggregation once the core prover alignment is complete.
+1. Mirror more of arkworks' domain helper caching where it materially helps
+   benchmarked prover paths.
+2. Continue prover-side MSM and fixed-base tuning against `prove_full`.
+3. Re-run benchmarks after each high-leverage domain/prover change.
+4. Port proof aggregation once the core prover path is stable.
 
 Feel free to extend this comparison as additional features (e.g., aggregation,
 poly-commitments) land in the Julia stack.

--- a/docs/PACKAGE_REFERENCE.md
+++ b/docs/PACKAGE_REFERENCE.md
@@ -23,8 +23,8 @@ annotated rather than discarded), and follow-ups.
 
 **Implementation notes**
 - (original) FFT helpers were stubs; dense interpolation handled `h(x)`.
-- (2025-09-29) Added `interpolate_prefix_points` so subset domains recover
-  coefficients before padding for coset FFTs.
+- (2025-09-29) Added FFT-domain guards and interpolation helpers used during the
+  early coset rollout.
 - (2026-04-01) Stage 2 of the Montgomery roadmap moved `BN254Fq` and
   `BN254Fr` to a 4-limb Montgomery representation behind the Stage 1 backend
   hooks. The higher layers still see canonical field semantics; compatibility
@@ -82,9 +82,10 @@ annotated rather than discarded), and follow-ups.
 **Implementation notes**
 - (original) QAP interpolation used dense Lagrange polys over `[1..n]`, with a
   future FFT path planned.
-- (2025-09-29) Coset path is default; dense vs coset equality asserted. Subset
-  domains recover coefficients via barycentric interpolation before FFT (dense
-  fallback retained for tests).
+- (2025-09-29) Coset path is default; dense vs coset equality asserted.
+- (2026-05-11) QAP conversion now matches arkworks domain population:
+  constraints first, public-input selector rows next, zero padding last, with
+  `t(x) = x^N - 1` over the full power-of-two domain.
 - (2026-04-02) The current follow-through work has shifted from broad backend
   migration to the remaining prover and pairing specialization steps surfaced
   by the Stage 8A baseline.
@@ -118,9 +119,10 @@ annotated rather than discarded), and follow-ups.
 - The focused backend profiles are now staged through `stage8a`, with
   deterministic prover fixtures and `_semantic` proof checks wired into the
   `prove_full` path.
-- Latest Stage 8A artifact: `benchmarks/artifacts/2026-04-01_223859`, with
-  `generated_24_constraints prove_full` at `28.873 ms`, `msm_b_g2` at
-  `4.334 ms`, `h_msm` at `7.036 ms`, and `final_c` at `2.804 ms`.
+- Latest QAP-domain-aligned Stage 8 artifact:
+  `benchmarks/artifacts/2026-05-11_130524`, with
+  `generated_24_constraints prove_full` at `29.989 ms`, `h_msm` at
+  `9.168 ms`, `l_msm` at `4.028 ms`, and `final_c` at `2.211 ms`.
 
 ## Docs
 
@@ -152,7 +154,7 @@ annotated rather than discarded), and follow-ups.
 ## Concrete Next Steps Checklist
 
 - [x] Coset FFT path default with dense assertion.
-- [ ] Align QAP domain population with arkworks.
+- [x] Align QAP domain population with arkworks.
 - [x] Implement variable-base Pippenger MSM and route prover query MSMs through it.
 - [ ] Extend MSM work with fixed-base Pippenger / further setup-side tuning if benchmarks justify it.
 - [ ] Prototype second pairing engine (BLS12-381).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,16 +6,16 @@ an arkworks-aligned, production-friendly Groth16 stack.
 
 ## Snapshot (September 2025)
 
-- **GrothAlgebra** — Prime fields, polynomials, MSM helpers in place. Coset path
-  now recovers coefficients via barycentric interpolation; FFT guard prevents
-  truncation. Pending: align evaluation domain population with arkworks and then
-  revisit FFT optimisations.
+- **GrothAlgebra** — Prime fields, polynomials, MSM helpers in place. FFT guards
+  prevent silent truncation, and QAP conversion now feeds full-domain vectors to
+  the IFFT directly.
 - **GrothCurves** — BN254 tower/curve/pairing fully implemented with pairing
   engine abstraction. Pending: second-curve prototype (e.g., BLS12-381) and
   optional GT optimisations.
-- **GrothProofs** — R1CS/QAP/Groth16 path mirrors arkworks; coset FFT is the
-  default. Dense path retained for assertions. Pending: domain alignment, optional
-  proof aggregation, polishing docs.
+- **GrothProofs** — R1CS/QAP/Groth16 path mirrors arkworks: constraints are
+  followed by public-input selector slots in the QAP domain, coset FFT is the
+  default, and the dense path is retained for assertions. Pending: optional proof
+  aggregation and polishing docs.
 - **GrothExamples** — Notebook-first tutorials now live in Pluto notebooks
   (`r1cs_qap_pluto.jl`, `r1cs_qap_groth_pluto.jl`) for side-by-side pedagogical
   and package-native walkthroughs.
@@ -24,18 +24,12 @@ an arkworks-aligned, production-friendly Groth16 stack.
 
 ## Near-term Focus
 
-1. **Align QAP domain with arkworks**
-   - Populate all domain slots (`num_constraints + num_inputs`, next power of
-     two) before IFFT.
-   - Remove the barycentric interpolation helper, rely on native IFFT/FFT.
-   - Update tests/examples/benchmarks accordingly.
-
-2. **Tooling & verification hardening**
+1. **Tooling & verification hardening**
    - Run JET sweeps after major refactors, keep coset/dense parity assertions.
    - Extend documentation (package reference, RareSkills map, implementation vs
      arkworks) as behaviour changes.
 
-3. **Documenter-based docs rollout**
+2. **Documenter-based docs rollout**
    - Inventory target modules/pages (`GrothAlgebra`, `GrothCurves`, `GrothProofs`, landing page) and decide how existing markdown (roadmap, implementation notes) folds into the site.
    - Maintain a dedicated `docs/Project.toml` environment with `Documenter`, `DocumenterTools`, `LiveServer`, and `dev` the in-tree packages for live loading (root workspace `Manifest.toml` remains canonical).
    - Seed `docs/make.jl` and `docs/src/index.md`; configure `makedocs` (site name, modules, `pages` layout, HTML settings, metadata, repo URL).
@@ -66,6 +60,8 @@ an arkworks-aligned, production-friendly Groth16 stack.
 ## Completed Milestones
 
 - Coset FFT path aligned (dense fallback removed, assertion on parity).
+- QAP domain alignment with arkworks: `num_constraints + num_public` slots feed
+  the IFFT, public-input selector rows are explicit, and `t(x) = x^N - 1`.
 - Prepared verifier matches arkworks (batched pairing path).
 - Benchmarks expanded (pairing & Groth16 hot paths with JSON/PNG artefacts).
 - Groth16 tests cover multiple circuits, randomized seeds, prepared-path

--- a/docs/RareSkills_Groth16_Map.md
+++ b/docs/RareSkills_Groth16_Map.md
@@ -25,7 +25,7 @@ graph TD
 
 ## Constraint Systems and Polynomial Encodings
 - **RareSkills chapters:** `rank-1-constraint-system`, `quadratic-constraints`, `quadratic-arithmetic-program`, and `r1cs-to-qap` show how circuits become matrices, then polynomials, culminating in $\mathcal{A}(x)\cdot\mathcal{B}(x) - \mathcal{C}(x) = Z_H(x) H(x)$.
-- **Julia counterparts:** `GrothProofs/R1CS.jl` now ships several fixtures (multiplication, sum-of-products, affine-product, square-offset) plus a seeded circuit generator used in tests (`GrothProofs/test/random_circuits.jl`). `QAP.jl` both records the first `n` constraint points and builds an FFT-friendly power-of-two domain; for `n < domain.size` we now recover the degree `< n` polynomials via barycentric interpolation before padding coefficients for the coset FFT pipeline (`GrothProofs/src/QAP.jl:40-134`).
+- **Julia counterparts:** `GrothProofs/R1CS.jl` now ships several fixtures (multiplication, sum-of-products, affine-product, square-offset) plus a seeded circuit generator used in tests (`GrothProofs/test/random_circuits.jl`). `QAP.jl` records the active constraint points while building an arkworks-shaped power-of-two domain: constraint rows first, public-input selector rows next, and zero padding last. The full-domain vanishing polynomial is `t(x) = x^N - 1`, and the coset quotient path consumes the IFFT output directly (`GrothProofs/src/QAP.jl`).
 
 - **Guidance on FFT vs. coset evaluation:** `docs/Implementation_vs_Arkworks.md` tracks the alignment with arkworks. Our prover now uses the coset-based quotient path by default, so the remaining work is performance-focused (benchmark capture, JET sweeps, possible FFT table reuse).
 

--- a/docs/src/algebra.md
+++ b/docs/src/algebra.md
@@ -25,7 +25,8 @@ Depth = 2
 
 ## Implementation Notes
 
-- Added `interpolate_prefix_points` so subset domains recover coefficients before padding for the coset FFT path.
+- FFT helpers guard against silent truncation and support the full-domain QAP
+  interpolation path used by Groth16.
 - FFT helpers now gate the dense fallback behind parity assertions.
 - BN254 `scalar_mul` now selects tuned w-NAF windows for G1/G2, while other group types keep the generic fallback.
 

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -229,6 +229,36 @@ main Stage 8A `prove_full` dump no longer contains `canonical_bigint` or
 `limbs_to_bigint`. The prover still creates `BigInt`s elsewhere, but the
 measured hot prover scalar-conversion path identified in Stage 8 is now gone.
 
+## QAP Domain Alignment Snapshot (2026-05-11)
+
+The QAP-domain-aligned Stage 8 run is:
+
+- `benchmarks/artifacts/2026-05-11_130524/results/benchmark_results.json`
+
+This run uses the arkworks-shaped QAP domain: active constraints first,
+public-input selector rows next, and zero padding to the next power of two. The
+fixture setup still proves once and asserts `verify_full` before timing.
+
+- `sum_of_products_small`
+  - constraints/public/domain: `3 / 6 / 16`
+  - `prove_full`: `11.298 ms`
+  - `compute_h_total`: `0.360 ms`
+  - `h_msm`: `5.702 ms`
+  - `final_c`: `2.222 ms`
+- `generated_24_constraints`
+  - constraints/public/domain: `24 / 8 / 32`
+  - `prove_full`: `29.989 ms`
+  - `compute_h_total`: `1.723 ms`
+  - `h_msm`: `9.168 ms`
+  - `l_msm`: `4.028 ms`
+  - `final_c`: `2.211 ms`
+
+Interpretation: the small fixture intentionally gets a larger domain because
+`3 constraints + 6 public` rounds up to `16`, so it is no longer directly
+comparable to the old constraint-only domain timing. The larger fixture already
+rounds to `32`, so it remains the better continuity fixture for prover-shaped
+tuning.
+
 ## Latest Snapshot (2025‑09‑29)
 
 ```@example

--- a/docs/src/implementation-notes.md
+++ b/docs/src/implementation-notes.md
@@ -43,8 +43,9 @@ Depth = 2
 
 - `R1CS.jl` defines reusable fixtures (multiplication, sum-of-products,
   affine-product, square-offset) and powers the randomised circuit generator.
-- `QAP.jl` records constraint points, builds power-of-two domains, and currently
-  recovers coefficients via barycentric interpolation before padding.
+- `QAP.jl` records constraint points and builds arkworks-shaped power-of-two
+  domains with constraint rows, public-input selector rows, and zero padding
+  explicit before IFFT.
 - `Groth16.jl` wires the setup, prover, and verifier paths, including the
   prepared verifier that batches pairings (`pairing_batch`) before the single
   final exponentiation.

--- a/docs/src/implementation-vs-arkworks.md
+++ b/docs/src/implementation-vs-arkworks.md
@@ -12,15 +12,15 @@ Depth = 2
 
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
-| Domain sizing | `EvaluationDomain::new(num_constraints + num_inputs)` fills every slot before the IFFT. | Currently we pick the smallest power-of-two ≥ `num_constraints`. When the circuit does not span the full domain we recover the coefficients via barycentric interpolation before padding. **Next step:** populate every slot so the coset FFT can consume the coefficients directly. |
+| Domain sizing | `EvaluationDomain::new(num_constraints + num_inputs)` fills every slot before the IFFT. | Matches arkworks' shape: constraint rows first, public-input selector rows next, then zero padding to the next power of two. |
 | Coset shift | `EvaluationDomain::get_coset(F::GENERATOR)` tracks offsets and inverses. | `get_coset(domain, default_coset_offset)` stores the offset, its inverse, and `offset_pow_size`. |
-| Vanishing polynomial on a coset | Cached evaluation via `domain.evaluate_vanishing_polynomial(g)`. | For full domains we use the closed form `g^n - 1`. Subset domains FFT `t(x)` on the coset; once the padding matches arkworks we can reuse cached evaluations. |
+| Vanishing polynomial on a coset | Cached evaluation via `domain.evaluate_vanishing_polynomial(g)`. | Uses the full-domain closed form `g^n - 1`, cached as a constant inverse over the shifted coset. |
 
 **Refactor snapshot (Sep 2025):**
 
 - Coset path is the default (`compute_h_polynomial` asserts coset vs dense parity).
-- Subset domains temporarily rebuild coefficients via barycentric interpolation before the FFT padding step.
-- Alignment plan: populate the full evaluation domain so the FFT/IFFT pair operates without the interpolation shim.
+- QAP conversion feeds full-domain evaluation vectors to IFFT directly, so the
+  Groth16 path no longer needs subset coefficient recovery.
 
 ## Multi-Scalar Multiplication (MSM)
 
@@ -45,8 +45,8 @@ tuning signal.
 
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
-| R1CS → QAP | Domain fully populated, IFFT then FFT on the coset. | Same structure; subset handling currently performs barycentric recovery before padding. |
-| Prover | Coset FFT path, dense available for debugging. | Coset path is default; dense exists only for assertions. Will align fully once domains match. |
+| R1CS → QAP | Domain fully populated, IFFT then FFT on the coset. | Same structure; constraints, public-input selector slots, and zero padding are all explicit before IFFT. |
+| Prover | Coset FFT path, dense available for debugging. | Coset path is default; dense exists only for assertions. |
 | Prepared verifier | `PreparedVerifyingKey` batches pairings. | `prepare_verifying_key`, `prepare_inputs`, and `verify_with_prepared` mirror the API. |
 | Aggregation | Optional `groth16::aggregate_proofs`. | Not yet ported; tracked on the roadmap. |
 

--- a/docs/src/proofs.md
+++ b/docs/src/proofs.md
@@ -24,8 +24,8 @@ Depth = 2
 ## Implementation Notes
 
 - Coset FFT path is the default; dense vs coset parity is asserted to guard regressions.
-- Subset domains currently recover coefficients via barycentric interpolation
-  before the FFT padding step.
+- QAP conversion uses an arkworks-shaped full domain: constraints first,
+  public-input selector rows next, zero padding last, and `t(x) = x^N - 1`.
 - The latest prover optimization work is now focused on the remaining
   specialization buckets surfaced by the Stage 8A `prove_full` baseline rather
   than on broad backend replacement.

--- a/docs/src/rareskills-map.md
+++ b/docs/src/rareskills-map.md
@@ -47,7 +47,7 @@ graph TD
 - **RareSkills chapters:** `rank-1-constraint-system`, `quadratic-arithmetic-program`, `r1cs-to-qap`.
 - **Groth.jl counterparts:**
   - `GrothProofs/R1CS.jl` ships multiplication, sum-of-products, affine-product, and square-offset circuits plus randomised fixtures.
-  - `GrothProofs/QAP.jl` records constraint points, constructs power-of-two domains, and currently recovers coefficients via barycentric interpolation before padding for the coset FFT.
+  - `GrothProofs/QAP.jl` records the active constraint points and builds an arkworks-shaped power-of-two domain: constraint rows first, public-input selector rows next, and zero padding last.
 - **What changes in code:** the prover defaults to the coset quotient path, and
   the dense path survives only as a parity assertion. The current performance
   work is now focused more on prover hot paths than on broad domain rewrites.


### PR DESCRIPTION
## Summary
- align R1CS-to-QAP conversion with the arkworks-shaped domain: constraints, public-input selector slots, then zero padding
- switch QAP target polynomial and coset vanishing cache to the full-domain `x^N - 1` form
- update tests, the package-native Pluto notebook, benchmark docs, and implementation references for the new layout

## Validation
- `Pkg.test()` for `GrothProofs`
- `include("scripts/test_all.jl")`
- `include("GrothExamples/src/r1cs_qap_groth_pluto.jl")`
- `include("docs/make.jl")` (Documenter deployment warning only; second in-session build also repeated DocTestSetup warnings)
- `benchmarks/run.jl --profile=stage8` -> `benchmarks/artifacts/2026-05-11_130524`
- `benchmarks/plot.jl 2026-05-11_130524`