### PR TITLE
groth16: use coset-only h in prover

### DIFF
--- a/GrothProofs/src/Groth16.jl
+++ b/GrothProofs/src/Groth16.jl
@@ -2,8 +2,8 @@
 Groth16 proof system implementation (production-style scaffold).
 
 Provides Proving/Verification keys and standard Groth16 equations.
-The prover uses the coset FFT pipeline by default; the dense path survives as a
-consistency check.
+The prover uses the coset FFT pipeline by default; dense/coset parity checks
+survive in tests and explicit debug helpers.
 """
 
 using GrothAlgebra
@@ -96,8 +96,8 @@ export Groth16Proof
     setup_full(qap::QAP{F}; rng=Random.GLOBAL_RNG, engine=BN254_ENGINE) where F
 
 Generate production-style Groth16 keys (ProvingKey, VerificationKey).
-Keys work with the coset FFT prover pipeline while retaining the dense fallback
-for parity assertions.
+Keys work with the coset FFT prover pipeline while retaining dense quotient
+helpers for tests and debugging.
 
 Security note: `rng` defaults to `Random.GLOBAL_RNG` (often `MersenneTwister`).
 Use a CSPRNG for real deployments.
@@ -217,15 +217,16 @@ function setup_full(qap::QAP{F}; rng::AbstractRNG=Random.GLOBAL_RNG, engine::Abs
 end
 
 """
-    prove_full(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng=Random.GLOBAL_RNG, debug_no_random=false) where F
+    prove_full(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng=Random.GLOBAL_RNG, debug_no_random=false, checked_h=false) where F
 
 Construct a Groth16 proof with the coset FFT pipeline.
 
 Set `debug_no_random=true` to omit prover randomness during testing.
+Set `checked_h=true` to compute dense/coset quotient parity during debugging.
 Security note: `rng` defaults to `Random.GLOBAL_RNG` (often `MersenneTwister`).
 Use a CSPRNG for real deployments.
 """
-function prove_full(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng::AbstractRNG=Random.GLOBAL_RNG, debug_no_random::Bool=false) where F
+function prove_full(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng::AbstractRNG=Random.GLOBAL_RNG, debug_no_random::Bool=false, checked_h::Bool=false) where F
     w_vals = witness.values
     m = qap.num_vars
 
@@ -244,9 +245,11 @@ function prove_full(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng::Abstr
     A = A1_g1 + scalar_mul(pk.delta_g1, r)
     B = pk.beta_g2 + B_acc_g2 + scalar_mul(pk.delta_g2, s)
 
-    # h(x): compute via coset FFT path and map coefficients via H_query
-    h_poly = compute_h_polynomial(qap, witness)
+    # h(x): compute via the fast coset-only FFT path unless debugging asks for
+    # the dense/coset parity check.
+    h_poly = checked_h ? compute_h_polynomial_checked(qap, witness) : compute_h_polynomial_coset(qap, witness)
     hk = length(h_poly.coeffs)
+    hk <= length(pk.H_query_g1) || error("H polynomial degree exceeds proving key H query length; witness may not satisfy the QAP")
     pts_h = pk.H_query_g1[1:hk]
     scalars_h = h_poly.coeffs
     H = GrothAlgebra.multi_scalar_mul(pts_h, scalars_h)
@@ -452,18 +455,18 @@ function setup(r1cs::R1CS{F}; rng::AbstractRNG=Random.GLOBAL_RNG, engine::Abstra
 end
 
 """
-    prove(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng=Random.GLOBAL_RNG, debug_no_random=false) where F
+    prove(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng=Random.GLOBAL_RNG, debug_no_random=false, checked_h=false) where F
 
 High-level proving wrapper over `prove_full`.
 """
-function prove(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng::AbstractRNG=Random.GLOBAL_RNG, debug_no_random::Bool=false) where F
+function prove(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng::AbstractRNG=Random.GLOBAL_RNG, debug_no_random::Bool=false, checked_h::Bool=false) where F
     if length(witness.values) != qap.num_vars
         throw(ArgumentError("Witness length $(length(witness.values)) does not match QAP num_vars $(qap.num_vars)"))
     end
     if !isone(witness.values[1])
         throw(ArgumentError("Witness convention violation: values[1] must be one($F)"))
     end
-    return prove_full(pk, qap, witness; rng=rng, debug_no_random=debug_no_random)
+    return prove_full(pk, qap, witness; rng=rng, debug_no_random=debug_no_random, checked_h=checked_h)
 end
 
 """

--- a/GrothProofs/src/QAP.jl
+++ b/GrothProofs/src/QAP.jl
@@ -140,19 +140,9 @@ function evaluate_qap(qap::QAP{F}, witness::Witness{F}, x::F) where F
     return (u_eval, v_eval, w_eval)
 end
 
-"""
-    compute_h_polynomial(qap::QAP{F}, witness::Witness{F}) where F
-
-Compute the quotient polynomial ``h(x)``:
-
-```math
-h(x) = \\frac{u(x)v(x) - w(x)}{t(x)}
-```
-"""
-function compute_h_polynomial(qap::QAP{F}, witness::Witness{F}; use_coset::Bool=true) where F
+function combined_qap_polynomials(qap::QAP{F}, witness::Witness{F}) where F
     w_vals = witness.values
 
-    # Compute linear combinations of polynomials
     u_poly = zero(Polynomial{F})
     v_poly = zero(Polynomial{F})
     w_poly = zero(Polynomial{F})
@@ -163,13 +153,20 @@ function compute_h_polynomial(qap::QAP{F}, witness::Witness{F}; use_coset::Bool=
         w_poly = w_poly + w_vals[i] * qap.w[i]
     end
 
+    return u_poly, v_poly, w_poly
+end
+
+function compute_h_polynomial_dense(qap::QAP{F}, u_poly::Polynomial{F}, v_poly::Polynomial{F}, w_poly::Polynomial{F}) where F
     p_poly = fft_polynomial_multiply(u_poly, v_poly) - w_poly
-    dense_result = polynomial_division(p_poly, qap.t)
+    return polynomial_division(p_poly, qap.t)
+end
 
-    if !use_coset
-        return dense_result
-    end
+function compute_h_polynomial_dense(qap::QAP{F}, witness::Witness{F}) where F
+    u_poly, v_poly, w_poly = combined_qap_polynomials(qap, witness)
+    return compute_h_polynomial_dense(qap, u_poly, v_poly, w_poly)
+end
 
+function compute_h_polynomial_coset(qap::QAP{F}, u_poly::Polynomial{F}, v_poly::Polynomial{F}, w_poly::Polynomial{F}) where F
     coset = qap.coset_domain
     u_eval = fft(u_poly.coeffs, coset)
     v_eval = fft(v_poly.coeffs, coset)
@@ -181,13 +178,39 @@ function compute_h_polynomial(qap::QAP{F}, witness::Witness{F}; use_coset::Bool=
         h_eval[i] = numerator * vanishing_inv[i]
     end
     coeffs = GrothAlgebra.ifft!(h_eval, coset)
-    dense_len = length(dense_result.coeffs)
-    dense_len < length(coeffs) && (coeffs = coeffs[1:dense_len])
-    coset_result = Polynomial{F}(coeffs)
+    return Polynomial{F}(coeffs)
+end
+
+function compute_h_polynomial_coset(qap::QAP{F}, witness::Witness{F}) where F
+    u_poly, v_poly, w_poly = combined_qap_polynomials(qap, witness)
+    return compute_h_polynomial_coset(qap, u_poly, v_poly, w_poly)
+end
+
+function compute_h_polynomial_checked(qap::QAP{F}, witness::Witness{F}) where F
+    u_poly, v_poly, w_poly = combined_qap_polynomials(qap, witness)
+    dense_result = compute_h_polynomial_dense(qap, u_poly, v_poly, w_poly)
+    coset_result = compute_h_polynomial_coset(qap, u_poly, v_poly, w_poly)
 
     coset_result == dense_result || error("Coset Groth16 path diverged from dense fallback")
 
     return coset_result
+end
+
+"""
+    compute_h_polynomial(qap::QAP{F}, witness::Witness{F}; use_coset::Bool=true) where F
+
+Compute the quotient polynomial ``h(x)``:
+
+```math
+h(x) = \\frac{u(x)v(x) - w(x)}{t(x)}
+```
+
+By default this computes both the dense quotient and the coset quotient and
+asserts that they agree. Pass `use_coset=false` for the dense quotient only.
+The prover's hot path calls the internal coset-only helper directly.
+"""
+function compute_h_polynomial(qap::QAP{F}, witness::Witness{F}; use_coset::Bool=true) where F
+    return use_coset ? compute_h_polynomial_checked(qap, witness) : compute_h_polynomial_dense(qap, witness)
 end
 
 """

--- a/GrothProofs/test/runtests.jl
+++ b/GrothProofs/test/runtests.jl
@@ -300,8 +300,10 @@ end
         end
 
         h_dense = compute_h_polynomial(qap, witness; use_coset=false)
-        h_coset = compute_h_polynomial(qap, witness; use_coset=true)
-        @test h_coset == h_dense
+        h_checked = compute_h_polynomial(qap, witness; use_coset=true)
+        h_fast = GrothProofs.compute_h_polynomial_coset(qap, witness)
+        @test h_checked == h_dense
+        @test h_fast == h_dense
     end
 end
 
@@ -355,9 +357,11 @@ end
 
         u_poly, v_poly, w_poly = combined_qap_polynomials(qap, w)
         h_dense = compute_h_polynomial(qap, w; use_coset=false)
-        h_coset = compute_h_polynomial(qap, w; use_coset=true)
-        @test h_coset == h_dense
-        h_poly = h_coset
+        h_checked = compute_h_polynomial(qap, w; use_coset=true)
+        h_fast = GrothProofs.compute_h_polynomial_coset(qap, w)
+        @test h_checked == h_dense
+        @test h_fast == h_dense
+        h_poly = h_fast
         t_poly = qap.t
 
         # Choose a few points outside the active constraint index range.
@@ -379,8 +383,10 @@ end
     @test qap_power.domain.size == next_power_of_two(r1cs_power.num_constraints + r1cs_power.num_public)
     witness_power = create_witness_square_offset(2, 3, 5)
     h_dense_power = compute_h_polynomial(qap_power, witness_power; use_coset=false)
-    h_coset_power = compute_h_polynomial(qap_power, witness_power; use_coset=true)
-    @test h_coset_power == h_dense_power
+    h_checked_power = compute_h_polynomial(qap_power, witness_power; use_coset=true)
+    h_fast_power = GrothProofs.compute_h_polynomial_coset(qap_power, witness_power)
+    @test h_checked_power == h_dense_power
+    @test h_fast_power == h_dense_power
 
     r1cs_subset = create_r1cs_example_multiplication()
     qap_subset = r1cs_to_qap(r1cs_subset)
@@ -388,8 +394,10 @@ end
     @test qap_subset.num_constraints < qap_subset.domain.size
     witness_subset = create_witness_multiplication(3, 5, 7, 11)
     h_dense_subset = compute_h_polynomial(qap_subset, witness_subset; use_coset=false)
-    h_coset_subset = compute_h_polynomial(qap_subset, witness_subset; use_coset=true)
-    @test h_coset_subset == h_dense_subset
+    h_checked_subset = compute_h_polynomial(qap_subset, witness_subset; use_coset=true)
+    h_fast_subset = GrothProofs.compute_h_polynomial_coset(qap_subset, witness_subset)
+    @test h_checked_subset == h_dense_subset
+    @test h_fast_subset == h_dense_subset
 end
 
 @testset "Groth16 rejects unsatisfied witness" begin
@@ -403,7 +411,18 @@ end
     bad_witness = Witness(bad_values)
     @test !is_satisfied(r1cs, bad_witness)
 
-    @test_throws ErrorException prove_full(keypair.pk, qap, bad_witness; rng=MersenneTwister(1234))
+    @test_throws ErrorException prove_full(keypair.pk, qap, bad_witness; rng=MersenneTwister(1234), checked_h=true)
+
+    fast_result = try
+        prove_full(keypair.pk, qap, bad_witness; rng=MersenneTwister(1234))
+    catch err
+        err
+    end
+    if fast_result isa Groth16Proof
+        @test !verify_full(keypair.vk, fast_result, public_inputs_for(r1cs, bad_witness))
+    else
+        @test fast_result isa Exception
+    end
 end
 
 @testset "High-level wrapper API and conventions" begin

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ The project has moved well beyond a minimal Groth16 demo.
 - QAP conversion now follows the arkworks domain shape: constraints first,
   public-input selector rows next, and zero padding to the next power of two.
 - The current larger deterministic `prove_full` baseline after QAP domain
-  alignment is `29.989 ms` in
-  [benchmarks/artifacts/2026-05-11_130524](./benchmarks/artifacts/2026-05-11_130524),
+  alignment and coset-only H proving is `28.636 ms` in
+  [benchmarks/artifacts/2026-05-11_133047](./benchmarks/artifacts/2026-05-11_133047),
   down from the original `136.187 ms` baseline captured at the start of the
   performance investigation.
 - The active roadmap has shifted from broad backend replacement to targeted

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -44,7 +44,7 @@ This directory contains a self-contained BenchmarkTools environment and four scr
   - continuity fixture: `sum_of_products_small`
   - larger deterministic fixture: `generated_24_constraints`
   - end-to-end prove time plus subphases for witness scalar conversion, query MSMs,
-    `compute_h_polynomial`, `H` MSM, `L` MSM, and final `C` assembly
+    coset-only H quotient computation, `H` MSM, `L` MSM, and final `C` assembly
 - Stage 8A prover scalar plumbing comparison
   - direct `BigInt` vs native `BN254Fr` comparisons for prover-like scalar
     multiplication and MSM workloads on the deterministic `generated_24_constraints`
@@ -321,35 +321,39 @@ The key profiler result is that the Stage 8A
 elsewhere, but the hot prover scalar conversions identified in Stage 8 have now
 been removed from the main `prove_full` path.
 
-## QAP Domain Alignment Snapshot (2026-05-11)
+## QAP Domain and H Quotient Snapshot (2026-05-11)
 
 - Stage 8 run:
-  `artifacts/2026-05-11_130524/results/benchmark_results.json`
+  `artifacts/2026-05-11_133047/results/benchmark_results.json`
 - Plots:
-  `artifacts/2026-05-11_130524/plots/`
+  `artifacts/2026-05-11_133047/plots/`
 
 This run uses the arkworks-shaped QAP domain: active constraints first,
-public-input selector rows next, and zero padding to the next power of two. The
-fixtures prove once and assert `verify_full` before timing.
+public-input selector rows next, and zero padding to the next power of two.
+`prove_full` computes H through the coset-only quotient path, while the checked
+dense/coset helper remains covered by tests. The fixtures prove once and assert
+`verify_full` before timing.
 
 - `sum_of_products_small`
   - constraints/public/domain: `3 / 6 / 16`
-  - `prove_full` end-to-end: `11.298 ms`
-  - `compute_h_total`: `0.360 ms`
-  - `h_msm`: `5.702 ms`
-  - `final_c`: `2.222 ms`
+  - `prove_full` end-to-end: `11.063 ms`
+  - `compute_h_total`: `0.243 ms`
+  - `h_msm`: `5.399 ms`
+  - `final_c`: `2.530 ms`
 - `generated_24_constraints`
   - constraints/public/domain: `24 / 8 / 32`
-  - `prove_full` end-to-end: `29.989 ms`
-  - `compute_h_total`: `1.723 ms`
-  - `h_msm`: `9.168 ms`
-  - `l_msm`: `4.028 ms`
-  - `final_c`: `2.211 ms`
+  - `prove_full` end-to-end: `28.636 ms`
+  - `compute_h_total`: `1.445 ms`
+  - `h_msm`: `8.925 ms`
+  - `l_msm`: `3.906 ms`
+  - `final_c`: `2.256 ms`
 
 The small fixture now has a larger QAP domain because `3 constraints + 6 public`
 rounds up to `16`; treat it as a correctness-and-continuity fixture, not as a
 like-for-like timing comparison with the old constraint-only layout. The
 generated fixture remains the better continuity signal for prover-shaped tuning.
+Relative to `2026-05-11_130524`, the generated fixture improved `prove_full` by
+`4.51%` and `compute_h_total` by `16.13%`.
 
 Generate a full report (run -> plot -> compare) for latest run:
 

--- a/benchmarks/profile_prove_full.jl
+++ b/benchmarks/profile_prove_full.jl
@@ -154,9 +154,9 @@ function main()
         )
         capture_profile(
             joinpath(profiles_dir, "compute_h_$(fixture.name).txt"),
-            "compute_h_polynomial",
+            "compute_h_polynomial_coset",
             fixture,
-            () -> compute_h_polynomial(fixture.qap, fixture.witness);
+            () -> GrothProofs.compute_h_polynomial_coset(fixture.qap, fixture.witness);
             repetitions = repetitions,
         )
         capture_profile(

--- a/benchmarks/run.jl
+++ b/benchmarks/run.jl
@@ -533,7 +533,7 @@ function bench_scalar_plumbing(results)
 
     witness_scalars_fr = witness_to_scalars(witness)
     witness_scalars_bigint = witness_to_scalars_bigint(witness)
-    h_poly = compute_h_polynomial(qap, witness)
+    h_poly = GrothProofs.compute_h_polynomial_coset(qap, witness)
     h_scalars_fr = h_poly.coeffs
     h_scalars_bigint = map(field_to_bigint, h_poly.coeffs)
     priv_scalars_fr = witness.values[(pk.num_public + 1):end]
@@ -1390,8 +1390,8 @@ function bench_prove_full(results)
         record_fixture_trial!(results, :prove_full, name, "msm_a_b1_g1", tr_msm_a_b1)
         record_fixture_trial!(results, :prove_full, name, "msm_b_g2", tr_msm_b2)
 
-        _ = compute_h_polynomial(qap, witness)
-        tr_h_total = @benchmark compute_h_polynomial($qap, $witness) seconds = 2 samples = 8
+        _ = GrothProofs.compute_h_polynomial_coset(qap, witness)
+        tr_h_total = @benchmark GrothProofs.compute_h_polynomial_coset($qap, $witness) seconds = 2 samples = 8
         print_stats("prove_full[$(name)] h_total", tr_h_total)
         record_fixture_trial!(results, :prove_full, name, "compute_h_total", tr_h_total)
 

--- a/docs/Implementation_vs_Arkworks.md
+++ b/docs/Implementation_vs_Arkworks.md
@@ -13,7 +13,8 @@ intentionally diverge from their design.
 | Vanishing on coset | `domain.evaluate_vanishing_polynomial(g)` with cached powers | Uses the full-domain closed form `g^n - 1`, cached as a constant inverse over the shifted coset |
 
 Aug 2025 refactor summary:
-- Coset path is default (`compute_h_polynomial` asserts coset/dense equality).
+- `prove_full` uses the coset-only quotient path; `compute_h_polynomial` remains
+  the checked dense/coset helper for tests and debugging.
 - QAP conversion feeds full-domain evaluation vectors to IFFT directly, so no
   subset coefficient recovery helper is needed for the Groth16 path.
 
@@ -40,7 +41,7 @@ prover path.
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
 | R1CS → QAP | Domain filled completely, IFFT → FFT on coset | Same structure; constraints, public-input selector slots, and zero padding are all explicit before IFFT |
-| Prover | Coset FFT path by default, dense path available for debugging | Coset path now default, dense used only for assertions |
+| Prover | Coset FFT path by default, dense path available for debugging | `prove_full` uses coset-only H computation; dense/coset parity is kept in explicit debug/test helpers |
 | Prepared verifier | `PreparedVerifyingKey` with batched pairing | `prepare_verifying_key`, `prepare_inputs`, `verify_with_prepared` mirror arkworks and use the pairing engine |
 | Aggregation | `groth16::aggregate_proofs` available | Not yet ported; on roadmap |
 

--- a/docs/PACKAGE_REFERENCE.md
+++ b/docs/PACKAGE_REFERENCE.md
@@ -82,10 +82,13 @@ annotated rather than discarded), and follow-ups.
 **Implementation notes**
 - (original) QAP interpolation used dense Lagrange polys over `[1..n]`, with a
   future FFT path planned.
-- (2025-09-29) Coset path is default; dense vs coset equality asserted.
+- (2025-09-29) Coset path became default with dense vs coset equality
+  assertions.
 - (2026-05-11) QAP conversion now matches arkworks domain population:
   constraints first, public-input selector rows next, zero padding last, with
   `t(x) = x^N - 1` over the full power-of-two domain.
+- (2026-05-11) `prove_full` now uses a coset-only H quotient path; the checked
+  dense/coset helper remains available for tests and debugging.
 - (2026-04-02) The current follow-through work has shifted from broad backend
   migration to the remaining prover and pairing specialization steps surfaced
   by the Stage 8A baseline.
@@ -119,10 +122,11 @@ annotated rather than discarded), and follow-ups.
 - The focused backend profiles are now staged through `stage8a`, with
   deterministic prover fixtures and `_semantic` proof checks wired into the
   `prove_full` path.
-- Latest QAP-domain-aligned Stage 8 artifact:
-  `benchmarks/artifacts/2026-05-11_130524`, with
-  `generated_24_constraints prove_full` at `29.989 ms`, `h_msm` at
-  `9.168 ms`, `l_msm` at `4.028 ms`, and `final_c` at `2.211 ms`.
+- Latest QAP-domain-aligned Stage 8 artifact after coset-only H proving:
+  `benchmarks/artifacts/2026-05-11_133047`, with
+  `generated_24_constraints prove_full` at `28.636 ms`, `compute_h_total` at
+  `1.445 ms`, `h_msm` at `8.925 ms`, `l_msm` at `3.906 ms`, and `final_c` at
+  `2.256 ms`.
 
 ## Docs
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,9 +13,9 @@ an arkworks-aligned, production-friendly Groth16 stack.
   engine abstraction. Pending: second-curve prototype (e.g., BLS12-381) and
   optional GT optimisations.
 - **GrothProofs** — R1CS/QAP/Groth16 path mirrors arkworks: constraints are
-  followed by public-input selector slots in the QAP domain, coset FFT is the
-  default, and the dense path is retained for assertions. Pending: optional proof
-  aggregation and polishing docs.
+  followed by public-input selector slots in the QAP domain, `prove_full` uses
+  the coset-only H path, and dense/coset quotient parity remains available for
+  tests and debugging. Pending: optional proof aggregation and polishing docs.
 - **GrothExamples** — Notebook-first tutorials now live in Pluto notebooks
   (`r1cs_qap_pluto.jl`, `r1cs_qap_groth_pluto.jl`) for side-by-side pedagogical
   and package-native walkthroughs.
@@ -62,6 +62,8 @@ an arkworks-aligned, production-friendly Groth16 stack.
 - Coset FFT path aligned (dense fallback removed, assertion on parity).
 - QAP domain alignment with arkworks: `num_constraints + num_public` slots feed
   the IFFT, public-input selector rows are explicit, and `t(x) = x^N - 1`.
+- `prove_full` now uses the coset-only H quotient path; dense/coset parity is
+  preserved in tests and debug helpers.
 - Prepared verifier matches arkworks (batched pairing path).
 - Benchmarks expanded (pairing & Groth16 hot paths with JSON/PNG artefacts).
 - Groth16 tests cover multiple circuits, randomized seeds, prepared-path

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -229,35 +229,38 @@ main Stage 8A `prove_full` dump no longer contains `canonical_bigint` or
 `limbs_to_bigint`. The prover still creates `BigInt`s elsewhere, but the
 measured hot prover scalar-conversion path identified in Stage 8 is now gone.
 
-## QAP Domain Alignment Snapshot (2026-05-11)
+## QAP Domain and H Quotient Snapshot (2026-05-11)
 
-The QAP-domain-aligned Stage 8 run is:
+The QAP-domain-aligned, coset-only H Stage 8 run is:
 
-- `benchmarks/artifacts/2026-05-11_130524/results/benchmark_results.json`
+- `benchmarks/artifacts/2026-05-11_133047/results/benchmark_results.json`
 
 This run uses the arkworks-shaped QAP domain: active constraints first,
-public-input selector rows next, and zero padding to the next power of two. The
-fixture setup still proves once and asserts `verify_full` before timing.
+public-input selector rows next, and zero padding to the next power of two.
+`prove_full` computes H through the coset-only quotient path, while the checked
+dense/coset helper remains covered by tests. The fixture setup still proves
+once and asserts `verify_full` before timing.
 
 - `sum_of_products_small`
   - constraints/public/domain: `3 / 6 / 16`
-  - `prove_full`: `11.298 ms`
-  - `compute_h_total`: `0.360 ms`
-  - `h_msm`: `5.702 ms`
-  - `final_c`: `2.222 ms`
+  - `prove_full`: `11.063 ms`
+  - `compute_h_total`: `0.243 ms`
+  - `h_msm`: `5.399 ms`
+  - `final_c`: `2.530 ms`
 - `generated_24_constraints`
   - constraints/public/domain: `24 / 8 / 32`
-  - `prove_full`: `29.989 ms`
-  - `compute_h_total`: `1.723 ms`
-  - `h_msm`: `9.168 ms`
-  - `l_msm`: `4.028 ms`
-  - `final_c`: `2.211 ms`
+  - `prove_full`: `28.636 ms`
+  - `compute_h_total`: `1.445 ms`
+  - `h_msm`: `8.925 ms`
+  - `l_msm`: `3.906 ms`
+  - `final_c`: `2.256 ms`
 
 Interpretation: the small fixture intentionally gets a larger domain because
 `3 constraints + 6 public` rounds up to `16`, so it is no longer directly
 comparable to the old constraint-only domain timing. The larger fixture already
 rounds to `32`, so it remains the better continuity fixture for prover-shaped
-tuning.
+tuning. Relative to `2026-05-11_130524`, the generated fixture improved
+`prove_full` by `4.51%` and `compute_h_total` by `16.13%`.
 
 ## Latest Snapshot (2025‑09‑29)
 

--- a/docs/src/implementation-vs-arkworks.md
+++ b/docs/src/implementation-vs-arkworks.md
@@ -18,7 +18,8 @@ Depth = 2
 
 **Refactor snapshot (Sep 2025):**
 
-- Coset path is the default (`compute_h_polynomial` asserts coset vs dense parity).
+- `prove_full` uses the coset-only quotient path; `compute_h_polynomial` remains
+  the checked dense/coset helper for tests and debugging.
 - QAP conversion feeds full-domain evaluation vectors to IFFT directly, so the
   Groth16 path no longer needs subset coefficient recovery.
 
@@ -46,7 +47,7 @@ tuning signal.
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
 | R1CS → QAP | Domain fully populated, IFFT then FFT on the coset. | Same structure; constraints, public-input selector slots, and zero padding are all explicit before IFFT. |
-| Prover | Coset FFT path, dense available for debugging. | Coset path is default; dense exists only for assertions. |
+| Prover | Coset FFT path, dense available for debugging. | `prove_full` uses coset-only H computation; dense/coset parity is kept in explicit debug/test helpers. |
 | Prepared verifier | `PreparedVerifyingKey` batches pairings. | `prepare_verifying_key`, `prepare_inputs`, and `verify_with_prepared` mirror the API. |
 | Aggregation | Optional `groth16::aggregate_proofs`. | Not yet ported; tracked on the roadmap. |
 

--- a/docs/src/proofs.md
+++ b/docs/src/proofs.md
@@ -23,7 +23,8 @@ Depth = 2
 
 ## Implementation Notes
 
-- Coset FFT path is the default; dense vs coset parity is asserted to guard regressions.
+- `prove_full` uses the coset-only H quotient path; dense vs coset parity is
+  still asserted in tests and available through the checked helper.
 - QAP conversion uses an arkworks-shaped full domain: constraints first,
   public-input selector rows next, zero padding last, and `t(x) = x^N - 1`.
 - The latest prover optimization work is now focused on the remaining

--- a/docs/src/rareskills-map.md
+++ b/docs/src/rareskills-map.md
@@ -48,9 +48,10 @@ graph TD
 - **Groth.jl counterparts:**
   - `GrothProofs/R1CS.jl` ships multiplication, sum-of-products, affine-product, and square-offset circuits plus randomised fixtures.
   - `GrothProofs/QAP.jl` records the active constraint points and builds an arkworks-shaped power-of-two domain: constraint rows first, public-input selector rows next, and zero padding last.
-- **What changes in code:** the prover defaults to the coset quotient path, and
-  the dense path survives only as a parity assertion. The current performance
-  work is now focused more on prover hot paths than on broad domain rewrites.
+- **What changes in code:** `prove_full` uses the coset-only quotient path, while
+  dense/coset parity survives in tests and debugging helpers. The current
+  performance work is focused more on prover hot paths than on broad domain
+  rewrites.
 
 ## Groth16 Pipeline
 


### PR DESCRIPTION
## Summary
- split H quotient computation into dense, coset-only, and checked dense/coset helper paths
- route `prove_full` through the coset-only H path by default, with `checked_h=true` available for debug parity checks
- update prover benchmark/profile scripts and docs to track the fast H path

## Validation
- `Pkg.test()` for `GrothProofs`
- `include("scripts/test_all.jl")`
- `include("docs/make.jl")` (Documenter deployment warning only)
- `benchmarks/run.jl --profile=stage8` -> `benchmarks/artifacts/2026-05-11_133047`
- `benchmarks/plot.jl 2026-05-11_133047`
- `benchmarks/compare.jl 2026-05-11_130524 2026-05-11_133047 20`

## Benchmark notes
- `generated_24_constraints prove_full`: `29.989 ms -> 28.636 ms` (4.51% faster)
- `generated_24_constraints compute_h_total`: `1.723 ms -> 1.445 ms` (16.13% faster)
- one tiny small-fixture `l_msm` metric crossed the 20% threshold (64 us -> 78 us), unrelated to this change