### PR TITLE
groth16: tune setup query generation

### DIFF
--- a/GrothAlgebra/src/Group.jl
+++ b/GrothAlgebra/src/Group.jl
@@ -948,6 +948,50 @@ function batch_mul(table::FixedBaseTable{G}, scalars::Vector{<:Integer}) where {
     return [mul_fixed(table, ki) for ki in scalars]
 end
 
+function _fixed_window_multiples(table::FixedBaseTable{G}) where {G<:GroupElem}
+    base = table.precomp[1]
+    multiples = Vector{G}(undef, 1 << table.window)
+    multiples[1] = zero(base)
+    multiples[2] = base
+    @inbounds for i in 3:length(multiples)
+        multiples[i] = multiples[i - 1] + base
+    end
+    return multiples
+end
+
+function _mul_fixed_windowed(multiples::Vector{G}, limbs::NTuple{4,UInt64}, bits::Int, window::Int) where {G<:GroupElem}
+    bits == 0 && return multiples[1]
+
+    acc = multiples[1]
+    top_shift = ((bits - 1) ÷ window) * window
+    first_window = true
+
+    @inbounds for shift in top_shift:-window:0
+        if first_window
+            first_window = false
+        else
+            for _ in 1:window
+                acc = acc + acc
+            end
+        end
+
+        digit = _limbs_window_digit(limbs, shift, window)
+        digit == 0 || (acc = acc + multiples[digit + 1])
+    end
+
+    return acc
+end
+
+function _batch_mul_fixed_window(table::FixedBaseTable{G}, scalars::Vector{BN254Fr}) where {G<:GroupElem}
+    multiples = _fixed_window_multiples(table)
+    points = Vector{G}(undef, length(scalars))
+    @inbounds for i in eachindex(scalars)
+        limbs = canonical_limbs(scalars[i])
+        points[i] = _mul_fixed_windowed(multiples, limbs, _limbs_bit_length(limbs), table.window)
+    end
+    return points
+end
+
 function batch_mul(table::FixedBaseTable{G}, scalars::Vector{BN254Fr}) where {G<:GroupElem}
     return [mul_fixed(table, ki) for ki in scalars]
 end

--- a/GrothAlgebra/test/test_groups.jl
+++ b/GrothAlgebra/test/test_groups.jl
@@ -193,8 +193,10 @@ using Test
     @testset "Fixed-base BN254Fr scalars" begin
         P = TestPoint(2, 3)
         table = build_fixed_table(P; window=4)
-        scalars = [bn254_fr(0), bn254_fr(1), bn254_fr(5), bn254_fr(17)]
-        @test batch_mul(table, scalars) == [scalar_mul(P, 0), scalar_mul(P, 1), scalar_mul(P, 5), scalar_mul(P, 17)]
+        scalar_ints = [BigInt(0), BigInt(1), BigInt(5), BigInt(17), (BigInt(1) << 180) + 12345]
+        scalars = map(bn254_fr, scalar_ints)
+        @test batch_mul(table, scalars) == [scalar_mul(P, k) for k in scalar_ints]
+        @test GrothAlgebra._batch_mul_fixed_window(table, scalars) == [scalar_mul(P, k) for k in scalar_ints]
     end
     
     @testset "w-NAF Scalar Multiplication" begin

--- a/GrothCurves/src/BN254Curve.jl
+++ b/GrothCurves/src/BN254Curve.jl
@@ -468,5 +468,56 @@ function _batch_to_affine!(pts::Vector{P}, ::Type{F}) where {F,P<:ProjectivePoin
     return pts
 end
 
+function _batch_to_affine_vectors!(vectors::Tuple{Vararg{Vector{P}}}, ::Type{F}) where {F,P<:ProjectivePoint{BN254Curve,F}}
+    n = 0
+    @inbounds for pts in vectors
+        n += length(pts)
+    end
+    n == 0 && return vectors
+
+    prefix = Vector{F}(undef, n)
+    running = one(F)
+    seen_nonzero = false
+    idx = 0
+
+    @inbounds for pts in vectors
+        for point in pts
+            idx += 1
+            if !iszero(point)
+                running = running * z_coord(point)
+                seen_nonzero = true
+            end
+            prefix[idx] = running
+        end
+    end
+
+    seen_nonzero || return vectors
+
+    inv_total = inv(running)
+    affine_z = one(F)
+    idx = n
+
+    @inbounds for pts in reverse(vectors)
+        for i in length(pts):-1:1
+            point = pts[i]
+            if !iszero(point)
+                prev = idx == 1 ? affine_z : prefix[idx - 1]
+                z_inv = inv_total * prev
+                inv_total = inv_total * z_coord(point)
+                z_inv2 = _square(z_inv)
+                pts[i] = P(x_coord(point) * z_inv2, y_coord(point) * z_inv2 * z_inv, affine_z)
+            end
+            idx -= 1
+        end
+    end
+
+    return vectors
+end
+
 batch_to_affine!(pts::Vector{G1Point}) = _batch_to_affine!(pts, BN254Fq)
 batch_to_affine!(pts::Vector{G2Point}) = _batch_to_affine!(pts, Fp2Element)
+
+batch_to_affine!(first::Vector{G1Point}, second::Vector{G1Point}, rest::Vector{G1Point}...) =
+    _batch_to_affine_vectors!((first, second, rest...), BN254Fq)
+batch_to_affine!(first::Vector{G2Point}, second::Vector{G2Point}, rest::Vector{G2Point}...) =
+    _batch_to_affine_vectors!((first, second, rest...), Fp2Element)

--- a/GrothCurves/test/test_bn254_curve.jl
+++ b/GrothCurves/test/test_bn254_curve.jl
@@ -183,6 +183,21 @@ glv_component_bits(component::Tuple{Bool,BigInt}) = iszero(component[2]) ? 0 : n
             @test z_coord(pts[3]) == one(BN254Fq)
             @test to_affine(pts[1]) == expected[1]
             @test to_affine(pts[3]) == expected[3]
+
+            left = [double(scalar_mul(g1_generator(), 11)), zero(G1Point)]
+            right = [double(scalar_mul(g1_generator(), 13)), double(scalar_mul(g1_generator(), 17))]
+            left_expected = [iszero(point) ? nothing : to_affine(point) for point in left]
+            right_expected = [to_affine(point) for point in right]
+
+            GrothCurves.batch_to_affine!(left, right)
+
+            @test z_coord(left[1]) == one(BN254Fq)
+            @test iszero(left[2])
+            @test z_coord(right[1]) == one(BN254Fq)
+            @test z_coord(right[2]) == one(BN254Fq)
+            @test to_affine(left[1]) == left_expected[1]
+            @test to_affine(right[1]) == right_expected[1]
+            @test to_affine(right[2]) == right_expected[2]
         end
     end
     
@@ -292,6 +307,21 @@ glv_component_bits(component::Tuple{Bool,BigInt}) = iszero(component[2]) ? 0 : n
             @test z_coord(pts[3]) == one(Fp2Element)
             @test to_affine(pts[1]) == expected[1]
             @test to_affine(pts[3]) == expected[3]
+
+            left = [double(scalar_mul(g2_generator(), 11)), zero(G2Point)]
+            right = [double(scalar_mul(g2_generator(), 13)), double(scalar_mul(g2_generator(), 17))]
+            left_expected = [iszero(point) ? nothing : to_affine(point) for point in left]
+            right_expected = [to_affine(point) for point in right]
+
+            GrothCurves.batch_to_affine!(left, right)
+
+            @test z_coord(left[1]) == one(Fp2Element)
+            @test iszero(left[2])
+            @test z_coord(right[1]) == one(Fp2Element)
+            @test z_coord(right[2]) == one(Fp2Element)
+            @test to_affine(left[1]) == left_expected[1]
+            @test to_affine(right[1]) == right_expected[1]
+            @test to_affine(right[2]) == right_expected[2]
         end
     end
 

--- a/GrothProofs/src/Groth16.jl
+++ b/GrothProofs/src/Groth16.jl
@@ -130,15 +130,16 @@ function setup_full(qap::QAP{F}; rng::AbstractRNG=Random.GLOBAL_RNG, engine::Abs
         C_eval[i] = evaluate(qap.w[i], τ)
     end
 
-    # Fixed-base tables for batch generation
-    g1tab = GrothAlgebra.build_fixed_table(g1)
-    g2tab = GrothAlgebra.build_fixed_table(g2)
+    # Fixed-base table for G2 query generation. G1 setup queries use the BN254
+    # scalar dispatcher because the measured GLV path beats fixed-base w-NAF for
+    # the full-width setup scalars used here.
+    g2tab = GrothAlgebra.build_fixed_table(g2; window=8)
 
-    # Map evaluations into group queries using fixed-base batch mul
-    A_query_g1 = GrothAlgebra.batch_mul(g1tab, A_eval)
-    B_query_g2 = GrothAlgebra.batch_mul(g2tab, B_eval)
-    B_query_g1 = GrothAlgebra.batch_mul(g1tab, B_eval)
-    C_query_g1 = GrothAlgebra.batch_mul(g1tab, C_eval)
+    # Map evaluations into group queries.
+    A_query_g1 = [scalar_mul(g1, s) for s in A_eval]
+    B_query_g2 = GrothAlgebra._batch_mul_fixed_window(g2tab, B_eval)
+    B_query_g1 = [scalar_mul(g1, s) for s in B_eval]
+    C_query_g1 = [scalar_mul(g1, s) for s in C_eval]
 
     # Target polynomial at τ
     t_tau = evaluate(qap.t, τ)
@@ -146,39 +147,41 @@ function setup_full(qap::QAP{F}; rng::AbstractRNG=Random.GLOBAL_RNG, engine::Abs
     # τ^k powers for H query. Since t has degree N over the full domain and
     # U,V,W have degree at most N-1, the quotient H has degree at most N-2.
     max_k = qap.domain.size - 1
-    tau_powers = Vector{F}(undef, max_k)
-    tau_powers[1] = one(F)
-    for k in 2:max_k
-        tau_powers[k] = tau_powers[k-1] * τ
+    H_scalars = Vector{F}(undef, max_k)
+    tau_power = one(F)
+    t_delta = t_tau * δ_inv
+    for k in 1:max_k
+        H_scalars[k] = t_delta * tau_power
+        tau_power *= τ
     end
 
     # H_query_g1: [τ^k · t(τ) / δ]₁
-    H_query_g1 = GrothAlgebra.batch_mul(g1tab, [t_tau * tau_powers[k] * δ_inv for k in 1:max_k])
+    H_query_g1 = [scalar_mul(g1, s) for s in H_scalars]
 
     # L_query for private variables only: [(β·u_i(τ) + α·v_i(τ) + w_i(τ)) / δ]₁
     num_public = qap.num_public
     L_query_g1 = G1Point[]
     if m > num_public
-        L_scalars = F[]
-        sizehint!(L_scalars, m - num_public)
+        L_scalars = Vector{F}(undef, m - num_public)
+        j = 0
         for i in (num_public+1):m
             acc = β * A_eval[i] + α * B_eval[i] + C_eval[i]
-            push!(L_scalars, acc * δ_inv)
+            j += 1
+            L_scalars[j] = acc * δ_inv
         end
-        L_query_g1 = GrothAlgebra.batch_mul(g1tab, L_scalars)
+        L_query_g1 = [scalar_mul(g1, s) for s in L_scalars]
     end
 
     # IC for public inputs: [(β·u_i(τ) + α·v_i(τ) + w_i(τ)) / γ]₁, including 1
-    IC_scalars = [(β * A_eval[i] + α * B_eval[i] + C_eval[i]) * γ_inv for i in 1:num_public]
-    IC = GrothAlgebra.batch_mul(g1tab, IC_scalars)
+    IC_scalars = Vector{F}(undef, num_public)
+    for i in 1:num_public
+        IC_scalars[i] = (β * A_eval[i] + α * B_eval[i] + C_eval[i]) * γ_inv
+    end
+    IC = [scalar_mul(g1, s) for s in IC_scalars]
 
-    # Normalize queries to affine for efficient storage
-    GrothCurves.batch_to_affine!(A_query_g1)
-    GrothCurves.batch_to_affine!(B_query_g1)
-    GrothCurves.batch_to_affine!(C_query_g1)
-    GrothCurves.batch_to_affine!(H_query_g1)
-    GrothCurves.batch_to_affine!(IC)
-    GrothCurves.batch_to_affine!(L_query_g1)
+    # Normalize G1 queries in one batch to pay only one inversion across the
+    # proving and verification query vectors.
+    GrothCurves.batch_to_affine!(A_query_g1, B_query_g1, C_query_g1, H_query_g1, IC, L_query_g1)
     GrothCurves.batch_to_affine!(B_query_g2)
 
     # Fixed elements

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ The project has moved well beyond a minimal Groth16 demo.
   [docs/src/assets/prove_full_msm_tuning_2026_05_11.json](./docs/src/assets/prove_full_msm_tuning_2026_05_11.json),
   down from the original `136.187 ms` baseline captured at the start of the
   performance investigation.
+- The current larger deterministic `setup_full` fixture is `116.918 ms` in
+  [docs/src/assets/setup_full_tuning_2026_05_11.json](./docs/src/assets/setup_full_tuning_2026_05_11.json),
+  down from the `142.715 ms` pre-change baseline on the same fixture.
 - The active roadmap has shifted from broad backend replacement to targeted
   specialization: limb-native inversion, final-exponentiation work, safer G2
   GLV exposure, prover-shaped MSM tuning, and then a fresh prover re-baseline.
@@ -165,6 +168,18 @@ Latest tracked `prove_full` prover fixture summary
 The generated fixture improved from `28.636 ms` to `26.643 ms` versus the
 previous coset-only H baseline by combining the separate H and L G1 MSMs into
 one MSM for the `C` proof element.
+
+Latest tracked `setup_full` fixture summary
+(`2026-05-11_175228`, setup profile):
+
+| Fixture | Domain | Baseline | Current |
+| --- | ---: | ---: | ---: |
+| `sum_of_products_small` | `16` | `47.910 ms` | `46.007 ms` |
+| `generated_24_constraints` | `32` | `142.715 ms` | `116.918 ms` |
+
+Setup now uses the BN254 G1 scalar dispatcher for G1 queries because the GLV
+path beats fixed-base w-NAF on the measured full-width setup scalars; the G2
+query keeps a fixed-window batch path.
 
 ## Performance Snapshot
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -361,6 +361,25 @@ generated fixture remains the better continuity signal for prover-shaped tuning.
 Relative to the previous coset-only H baseline `2026-05-11_133047`, the
 generated fixture improved `prove_full` by `6.96%` and `final_c` by `5.14%`.
 
+## Setup Query Generation Snapshot (2026-05-11)
+
+- Setup profile run:
+  `artifacts/2026-05-11_175228/results/benchmark_results.json`
+- Tracked summary:
+  `../docs/src/assets/setup_full_tuning_2026_05_11.json`
+
+The setup profile times `setup_full` on the same deterministic fixtures used by
+the prover benchmark. It proves and verifies once per fixture before timing.
+
+| Fixture | Domain | Baseline median | Current median | Change |
+| --- | ---: | ---: | ---: | ---: |
+| `sum_of_products_small` | `16` | `47.910 ms` | `46.007 ms` | `-3.97%` |
+| `generated_24_constraints` | `32` | `142.715 ms` | `116.918 ms` | `-18.08%` |
+
+The setup pass keeps a fixed-window batch path for the G2 query, but routes G1
+setup queries through the BN254 scalar dispatcher because the measured GLV path
+beats fixed-base w-NAF for the full-width setup scalars.
+
 Generate a full report (run -> plot -> compare) for latest run:
 
 ```

--- a/benchmarks/run.jl
+++ b/benchmarks/run.jl
@@ -34,6 +34,7 @@ const BENCHMARK_GROUP_ORDER = [
     :pairing_substeps,
     :py_ecc_primitives,
     :groth16,
+    :setup_full,
     :prove_full,
 ]
 const BENCHMARK_PROFILES = Dict(
@@ -47,6 +48,7 @@ const BENCHMARK_PROFILES = Dict(
     "stage7a" => [:bn254_primitives, :glv_scalar_tuning],
     "stage8" => [:prove_full],
     "stage8a" => [:scalar_plumbing, :prove_full],
+    "setup" => [:setup_full],
     "primitives" => [:bn254_primitives, :pairing_micro, :py_ecc_primitives],
 )
 
@@ -1446,6 +1448,24 @@ function bench_prove_full(results)
     end
 end
 
+function bench_setup_full(results)
+    println("\n== setup_full fixture baseline ==")
+    for fixture in default_prove_full_fixtures()
+        name = fixture.name
+        println("Fixture: $(name)")
+        println("  ", fixture.description)
+        println("  constraints=$(fixture.r1cs.num_constraints) vars=$(fixture.r1cs.num_vars) public=$(fixture.r1cs.num_public) domain=$(fixture.qap.domain.size)")
+
+        keypair = setup_full(fixture.qap; rng=MersenneTwister(fixture.setup_seed))
+        proof = prove_full(keypair.pk, fixture.qap, fixture.witness; rng=MersenneTwister(fixture.prove_seed))
+        verify_full(keypair.vk, proof, fixture.public_inputs) || error("setup_full[$(name)] produced keys that failed proof verification")
+
+        tr_setup = @benchmark setup_full($(fixture.qap); rng=MersenneTwister($(fixture.setup_seed))) seconds = 3 samples = 8
+        print_stats("setup_full[$(name)] end", tr_setup)
+        record_fixture_trial!(results, :setup_full, name, "end_to_end", tr_setup)
+    end
+end
+
 # -----------------------------------------------------------------------------
 # Entry point
 # -----------------------------------------------------------------------------
@@ -1494,6 +1514,7 @@ function main()
     :pairing_substeps in selected && bench_pairing_substeps(results)
     :py_ecc_primitives in selected && bench_py_ecc_primitives(results, meta)
     :groth16 in selected && bench_groth16(results)
+    :setup_full in selected && bench_setup_full(results)
     :prove_full in selected && bench_prove_full(results)
 
     results_out = joinpath(results_dir, "benchmark_results.json")

--- a/docs/Implementation_vs_Arkworks.md
+++ b/docs/Implementation_vs_Arkworks.md
@@ -23,7 +23,7 @@ Aug 2025 refactor summary:
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
 | MSM backend | `VariableBaseMSM` (Straus + endomorphism on BLS curves) | `GrothAlgebra.multi_scalar_mul` now uses a Pippenger-style variable-base backend with a small-input Straus fallback; w-NAF helpers remain shared. Endomorphism optimisations TBD |
-| Fixed-base tables | `FixedBaseMSM` with windowing | `FixedBaseTable` in `GrothAlgebra/src/Group.jl`; benchmarks cover table build & batch multiply |
+| Fixed-base tables | `FixedBaseMSM` with windowing | `FixedBaseTable` in `GrothAlgebra/src/Group.jl`; setup uses measured BN254 scalar/GLV dispatch for G1 query generation and a fixed-window batch path for the G2 query |
 
 Planned work: evaluate window sizes and endomorphisms once we profile the coset
 prover path.
@@ -41,7 +41,7 @@ prover path.
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
 | R1CS → QAP | Domain filled completely, IFFT → FFT on coset | Same structure; constraints, public-input selector slots, and zero padding are all explicit before IFFT |
-| Prover | Coset FFT path by default, dense path available for debugging | `prove_full` uses coset-only H computation and combines H/L into one G1 MSM for `C`; dense/coset parity is kept in explicit debug/test helpers |
+| Prover/setup | Coset FFT path by default, dense path available for debugging | `prove_full` uses coset-only H computation and combines H/L into one G1 MSM for `C`; `setup_full` uses measured query-generation dispatch; dense/coset parity is kept in explicit debug/test helpers |
 | Prepared verifier | `PreparedVerifyingKey` with batched pairing | `prepare_verifying_key`, `prepare_inputs`, `verify_with_prepared` mirror arkworks and use the pairing engine |
 | Aggregation | `groth16::aggregate_proofs` available | Not yet ported; on roadmap |
 

--- a/docs/PACKAGE_REFERENCE.md
+++ b/docs/PACKAGE_REFERENCE.md
@@ -92,6 +92,9 @@ annotated rather than discarded), and follow-ups.
 - (2026-05-11) The prover combines the H and private-variable L contributions
   into one G1 MSM for the `C` proof element, preserving the same `H + L`
   algebra while reducing prover-shaped MSM work on the deterministic fixture.
+- (2026-05-11) `setup_full` routes G1 query generation through the BN254 scalar
+  dispatcher, whose GLV path beats fixed-base w-NAF for the measured setup
+  scalars; the G2 query uses a fixed-window batch path.
 - (2026-04-02) The current follow-through work has shifted from broad backend
   migration to the remaining prover and pairing specialization steps surfaced
   by the Stage 8A baseline.
@@ -131,6 +134,10 @@ annotated rather than discarded), and follow-ups.
   `generated_24_constraints` fixture reports `prove_full` at `26.643 ms`,
   `compute_h_total` at `1.481 ms`, `h_msm` at `8.726 ms`, `l_msm` at
   `3.871 ms`, `h_l_msm` at `11.029 ms`, and `final_c` at `2.140 ms`.
+- Latest setup-focused artifact: `benchmarks/artifacts/2026-05-11_175228`,
+  with tracked summary `docs/src/assets/setup_full_tuning_2026_05_11.json`.
+  The `generated_24_constraints` fixture reports `setup_full` at `116.918 ms`,
+  down from the `142.715 ms` pre-change baseline.
 
 ## Docs
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,8 @@ an arkworks-aligned, production-friendly Groth16 stack.
   optional GT optimisations.
 - **GrothProofs** — R1CS/QAP/Groth16 path mirrors arkworks: constraints are
   followed by public-input selector slots in the QAP domain, `prove_full` uses
-  the coset-only H path, combines H/L into one prover MSM, and dense/coset
+  the coset-only H path, combines H/L into one prover MSM, setup query
+  generation uses the measured BN254 scalar/GLV path for G1, and dense/coset
   quotient parity remains available for tests and debugging. Pending: optional
   proof aggregation and polishing docs.
 - **GrothExamples** — Notebook-first tutorials now live in Pluto notebooks
@@ -68,6 +69,9 @@ an arkworks-aligned, production-friendly Groth16 stack.
 - `prove_full` combines the H and private-variable L contributions into one G1
   MSM for the `C` proof element; the Stage 8 generated fixture is now
   `26.643 ms`.
+- `setup_full` query generation now uses BN254 G1 scalar/GLV dispatch for G1
+  queries and a fixed-window G2 batch path; the generated fixture is now
+  `116.918 ms`.
 - Prepared verifier matches arkworks (batched pairing path).
 - Benchmarks expanded (pairing & Groth16 hot paths with JSON/PNG artefacts).
 - Groth16 tests cover multiple circuits, randomized seeds, prepared-path

--- a/docs/src/assets/setup_full_tuning_2026_05_11.json
+++ b/docs/src/assets/setup_full_tuning_2026_05_11.json
@@ -1,0 +1,36 @@
+{
+  "summary": "Setup query-generation tuning: G1 setup queries now use the BN254 scalar dispatcher, whose measured GLV path beats fixed-base w-NAF for full-width setup scalars; the G2 query uses a fixed-window batch path.",
+  "candidate_run_id": "2026-05-11_175228",
+  "benchmark_profile": "setup",
+  "julia_version": "1.12.6",
+  "threadpools": {
+    "default": 24,
+    "interactive": 1
+  },
+  "cpu": "znver5",
+  "fixtures": {
+    "sum_of_products_small": {
+      "constraints": 3,
+      "public_inputs": 6,
+      "domain_size": 16,
+      "baseline_median_ms": 47.91,
+      "candidate_median_ms": 46.007,
+      "relative_to_baseline": "-3.97%",
+      "candidate_memory_bytes": 39455512
+    },
+    "generated_24_constraints": {
+      "constraints": 24,
+      "public_inputs": 8,
+      "domain_size": 32,
+      "baseline_median_ms": 142.715,
+      "candidate_median_ms": 116.918,
+      "relative_to_baseline": "-18.08%",
+      "candidate_memory_bytes": 103991784
+    }
+  },
+  "notes": [
+    "Baseline medians were captured before the branch changes using the same deterministic fixtures and setup seeds.",
+    "The setup profile proves and verifies once per fixture before timing setup_full.",
+    "Stage 8 prove_full rerun 2026-05-11_175426 reported no regressions above the configured 20% threshold versus 2026-05-11_165756."
+  ]
+}

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -284,6 +284,31 @@ rounds to `32`, so it remains the better continuity fixture for prover-shaped
 tuning. Relative to the previous coset-only H baseline `2026-05-11_133047`, the
 generated fixture improved `prove_full` by `6.96%` and `final_c` by `5.14%`.
 
+## Setup Query Generation Snapshot (2026-05-11)
+
+The setup-focused artifact is:
+
+- tracked summary:
+  `docs/src/assets/setup_full_tuning_2026_05_11.json`
+- local full artifact:
+  `benchmarks/artifacts/2026-05-11_175228/results/benchmark_results.json`
+
+The setup profile times `setup_full` on the same deterministic fixtures used by
+the prover benchmark. It proves and verifies once per fixture before timing, so
+the measured keys are checked for end-to-end Groth16 usability.
+
+| Fixture | Domain | Baseline median | Current median | Change |
+| --- | ---: | ---: | ---: | ---: |
+| `sum_of_products_small` | `16` | `47.910 ms` | `46.007 ms` | `-3.97%` |
+| `generated_24_constraints` | `32` | `142.715 ms` | `116.918 ms` | `-18.08%` |
+
+Interpretation: the setup sweep showed that G1 fixed-base w-NAF is not the best
+choice for the full-width setup scalars in these fixtures. `setup_full` now
+uses the BN254 G1 scalar dispatcher, whose GLV path is faster for those scalars,
+while the G2 query uses a wider fixed-window batch path. The generated fixture
+is again the better continuity signal because it exercises a larger set of
+query scalars.
+
 ## Latest Snapshot (2025‑09‑29)
 
 ```@example

--- a/docs/src/implementation-vs-arkworks.md
+++ b/docs/src/implementation-vs-arkworks.md
@@ -28,7 +28,7 @@ Depth = 2
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
 | Variable-base MSM | Straus / Pippenger variants with endomorphism support where safe. | `GrothAlgebra.multi_scalar_mul` uses a Pippenger-style backend with a small-input Straus fallback; BN254 G1 now has a measured hybrid GLV path, and G2 has an internal GLV path that is not yet the unconditional public default. |
-| Fixed-base tables | `FixedBaseMSM` window tables. | `FixedBaseTable` plus `build_fixed_table`, `mul_fixed`, and `batch_mul` mirror the workflow; benchmarks track table build vs reuse. |
+| Fixed-base tables | `FixedBaseMSM` window tables. | `FixedBaseTable` plus `build_fixed_table`, `mul_fixed`, and `batch_mul` mirror the workflow; setup uses measured BN254 scalar/GLV dispatch for G1 query generation and a fixed-window batch path for the G2 query. |
 
 **Next steps:** keep MSM work tied to the real `prove_full` fixtures, pursue
 safe G2 GLV exposure, and avoid treating synthetic MSM sweeps as the sole
@@ -47,7 +47,7 @@ tuning signal.
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
 | R1CS → QAP | Domain fully populated, IFFT then FFT on the coset. | Same structure; constraints, public-input selector slots, and zero padding are all explicit before IFFT. |
-| Prover | Coset FFT path, dense available for debugging. | `prove_full` uses coset-only H computation and combines H/L into one G1 MSM for `C`; dense/coset parity is kept in explicit debug/test helpers. |
+| Prover/setup | Coset FFT path, dense available for debugging. | `prove_full` uses coset-only H computation and combines H/L into one G1 MSM for `C`; `setup_full` uses measured query-generation dispatch; dense/coset parity is kept in explicit debug/test helpers. |
 | Prepared verifier | `PreparedVerifyingKey` batches pairings. | `prepare_verifying_key`, `prepare_inputs`, and `verify_with_prepared` mirror the API. |
 | Aggregation | Optional `groth16::aggregate_proofs`. | Not yet ported; tracked on the roadmap. |
 

--- a/docs/src/proofs.md
+++ b/docs/src/proofs.md
@@ -27,6 +27,8 @@ Depth = 2
   still asserted in tests and available through the checked helper.
 - The prover combines H and private-variable L into one G1 MSM for the `C`
   proof element, since the algebra only needs their sum.
+- `setup_full` uses the measured BN254 G1 scalar/GLV path for G1 query
+  generation and a fixed-window batch path for the G2 query.
 - QAP conversion uses an arkworks-shaped full domain: constraints first,
   public-input selector rows next, zero padding last, and `t(x) = x^N - 1`.
 - The latest prover optimization work is now focused on the remaining


### PR DESCRIPTION
## Summary

- route G1 setup query generation through the BN254 scalar dispatcher because the measured GLV path beats fixed-base w-NAF for the setup scalars
- add an internal fixed-window batch helper for the G2 setup query
- normalize G1 setup query vectors in one batch and avoid temporary H/L/IC scalar comprehensions
- add a `setup` benchmark profile plus docs/tracked summary for the setup fixture results

## Validation

- `scripts/test_all.jl` passed
- `docs/make.jl` passed
- setup profile artifact `2026-05-11_175228` completed and verifies generated keys before timing
- Stage 8 artifact `2026-05-11_175426` completed
- `benchmarks/compare.jl 2026-05-11_165756 2026-05-11_175426 20` reported no prove_full regressions above threshold

## Benchmark Notes

Setup fixture medians:

- `sum_of_products_small`: `47.910 ms -> 46.007 ms` (`-3.97%`)
- `generated_24_constraints`: `142.715 ms -> 116.918 ms` (`-18.08%`)

The generated fixture is the better setup continuity signal because it exercises more query scalars.
