### PR TITLE
curves: expose safe g2 subgroup glv

### DIFF
--- a/GrothCurves/src/BN254Curve.jl
+++ b/GrothCurves/src/BN254Curve.jl
@@ -236,6 +236,19 @@ function glv_scalar_mul(p::P, k::GrothAlgebra.BN254Fr) where {P<:ProjectivePoint
 end
 
 """
+    g2_subgroup_scalar_mul(p::G2Point, k::Integer)
+    g2_subgroup_scalar_mul(p::G2Point, k::GrothAlgebra.BN254Fr)
+
+Multiply a BN254 G2 point by `k` using the GLV endomorphism, assuming `p` is
+already known to be in the prime-order G2 subgroup.
+
+The generic `scalar_mul(::G2Point, ...)` path intentionally remains the safe
+default for arbitrary on-curve points, including verifier subgroup checks.
+"""
+g2_subgroup_scalar_mul(p::G2Point, k::Integer) = glv_scalar_mul(p, k)
+g2_subgroup_scalar_mul(p::G2Point, k::GrothAlgebra.BN254Fr) = glv_scalar_mul(p, k)
+
+"""
     GrothAlgebra.scalar_mul(p::G1Point, k::Integer)
     GrothAlgebra.scalar_mul(p::G1Point, k::GrothAlgebra.BN254Fr)
 

--- a/GrothCurves/src/GrothCurves.jl
+++ b/GrothCurves/src/GrothCurves.jl
@@ -38,6 +38,7 @@ export Fp6Element, Fp12Element, GTElement, square
 export BN254Curve, G1Point, G2Point, BN254Engine, BN254_ENGINE
 export to_affine, is_on_curve, double, batch_to_affine!
 export g1_generator, g2_generator
+export g2_subgroup_scalar_mul
 export x_coord, y_coord, z_coord
 export LineCoeffs, doubling_step, addition_step, evaluate_line, miller_loop, frobenius_g2
 export frobenius_map, frobenius_p1, frobenius_p2, frobenius_p3

--- a/GrothCurves/test/test_bn254_curve.jl
+++ b/GrothCurves/test/test_bn254_curve.jl
@@ -395,7 +395,33 @@ glv_component_bits(component::Tuple{Bool,BigInt}) = iszero(component[2]) ? 0 : n
                 -(GrothCurves.BN254_ORDER_R - 8765432),
             )
                 @test GrothCurves.glv_scalar_mul(g2, scalar) == scalar_mul_reference(g2, scalar)
+                @test g2_subgroup_scalar_mul(g2, scalar) == scalar_mul_reference(g2, scalar)
                 @test scalar_mul(g2, scalar) == scalar_mul_reference(g2, scalar)
+            end
+        end
+
+        @testset "G2 subgroup GLV helper keeps generic scalar semantics explicit" begin
+            g2 = g2_generator()
+            subgroup_point = scalar_mul_reference(g2, benchmark_scalar(507))
+            test_scalars = (
+                0,
+                1,
+                -1,
+                23,
+                benchmark_scalar(508),
+                -benchmark_scalar(509),
+                GrothCurves.BN254_ORDER_R - 3456789,
+            )
+
+            for scalar in test_scalars
+                expected = scalar_mul_reference(subgroup_point, scalar)
+                @test g2_subgroup_scalar_mul(subgroup_point, scalar) == expected
+                @test scalar_mul(subgroup_point, scalar) == expected
+
+                bits = GrothAlgebra._bit_length(scalar)
+                window = GrothAlgebra._scalar_mul_window(G2Point, bits)
+                @test scalar_mul(subgroup_point, scalar) ==
+                      scalar_mul_wnaf(subgroup_point, scalar, window)
             end
         end
 
@@ -413,6 +439,7 @@ glv_component_bits(component::Tuple{Bool,BigInt}) = iszero(component[2]) ? 0 : n
                 scalar_big = convert(BigInt, scalar)
                 @test scalar_mul(g1, scalar) == scalar_mul_reference(g1, scalar_big)
                 @test scalar_mul(g2, scalar) == scalar_mul_reference(g2, scalar_big)
+                @test g2_subgroup_scalar_mul(g2, scalar) == scalar_mul_reference(g2, scalar_big)
             end
 
             g1_points = [scalar_mul(g1, 3), scalar_mul(g1, 5), scalar_mul(g1, 7)]

--- a/GrothProofs/src/Groth16.jl
+++ b/GrothProofs/src/Groth16.jl
@@ -187,10 +187,10 @@ function setup_full(qap::QAP{F}; rng::AbstractRNG=Random.GLOBAL_RNG, engine::Abs
     # Fixed elements
     alpha_g1 = scalar_mul(g1, α)
     beta_g1 = scalar_mul(g1, β)
-    beta_g2 = scalar_mul(g2, β)
-    gamma_g2 = scalar_mul(g2, γ)
+    beta_g2 = g2_subgroup_scalar_mul(g2, β)
+    gamma_g2 = g2_subgroup_scalar_mul(g2, γ)
     delta_g1 = scalar_mul(g1, δ)
-    delta_g2 = scalar_mul(g2, δ)
+    delta_g2 = g2_subgroup_scalar_mul(g2, δ)
 
     pk = ProvingKey(
         alpha_g1,
@@ -246,7 +246,7 @@ function prove_full(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng::Abstr
     A1_g1 = pk.alpha_g1 + A_acc_g1
     B1_g1 = pk.beta_g1 + B_acc_g1
     A = A1_g1 + scalar_mul(pk.delta_g1, r)
-    B = pk.beta_g2 + B_acc_g2 + scalar_mul(pk.delta_g2, s)
+    B = pk.beta_g2 + B_acc_g2 + g2_subgroup_scalar_mul(pk.delta_g2, s)
 
     # h(x): compute via the fast coset-only FFT path unless debugging asks for
     # the dense/coset parity check.

--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ The project has moved well beyond a minimal Groth16 demo.
 - The current larger deterministic `setup_full` fixture is `116.918 ms` in
   [docs/src/assets/setup_full_tuning_2026_05_11.json](./docs/src/assets/setup_full_tuning_2026_05_11.json),
   down from the `142.715 ms` pre-change baseline on the same fixture.
+- Groth16 setup/proving now use an explicit G2 subgroup GLV helper for
+  construction-owned key points, while generic G2 scalar multiplication remains
+  the safe path for arbitrary verifier input.
 - The active roadmap has shifted from broad backend replacement to targeted
-  specialization: limb-native inversion, final-exponentiation work, safer G2
-  GLV exposure, prover-shaped MSM tuning, and then a fresh prover re-baseline.
+  specialization: limb-native inversion, final-exponentiation work,
+  prover-shaped MSM tuning, and then a fresh prover re-baseline.
 
 See [ROADMAP.md](./ROADMAP.md) for the staged backend history and remaining
 specialization work.
@@ -179,7 +182,10 @@ Latest tracked `setup_full` fixture summary
 
 Setup now uses the BN254 G1 scalar dispatcher for G1 queries because the GLV
 path beats fixed-base w-NAF on the measured full-width setup scalars; the G2
-query keeps a fixed-window batch path.
+query keeps a fixed-window batch path. Fixed G2 key elements and the prover's
+`delta_g2` randomizer term use an explicit subgroup-only GLV helper, preserving
+the generic G2 scalar path for arbitrary on-curve points and verifier subgroup
+checks.
 
 ## Performance Snapshot
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -380,6 +380,29 @@ The setup pass keeps a fixed-window batch path for the G2 query, but routes G1
 setup queries through the BN254 scalar dispatcher because the measured GLV path
 beats fixed-base w-NAF for the full-width setup scalars.
 
+## Safe G2 Subgroup GLV Snapshot (2026-05-11)
+
+- Focused run:
+  `artifacts/2026-05-11_190310/results/benchmark_results.json`
+- Tracked summary:
+  `../docs/src/assets/g2_subgroup_glv_tuning_2026_05_11.json`
+
+The G2 scalar policy sweep now reports the arbitrary-point default, explicit
+w-NAF, and the subgroup-only GLV helper separately:
+
+| Scalar bits | G2 default | G2 w-NAF | G2 subgroup GLV |
+| --- | ---: | ---: | ---: |
+| `32` | `0.335 ms` | `0.314 ms` | `0.335 ms` |
+| `64` | `0.525 ms` | `0.530 ms` | `0.554 ms` |
+| `128` | `1.014 ms` | `1.072 ms` | `1.504 ms` |
+| `192` | `1.544 ms` | `1.632 ms` | `1.609 ms` |
+| `254` | `2.455 ms` | `2.440 ms` | `1.612 ms` |
+
+The subgroup helper is deliberately explicit: it is only valid for points
+already known to be in `G2[r]`. Groth16 setup/proving uses it for fixed G2 key
+points constructed from the generator; verifier subgroup checks keep generic
+G2 scalar multiplication for arbitrary proof input.
+
 Generate a full report (run -> plot -> compare) for latest run:
 
 ```

--- a/benchmarks/plot.jl
+++ b/benchmarks/plot.jl
@@ -116,10 +116,12 @@ function plot_categorical_group(results::AbstractDict, out_dir::String, key::Sym
     group === nothing && return
     present = [category for category in categories if haskey(group, category)]
     isempty(present) && return
-    data = [median_ms(group[category][labels[j]]) for j in eachindex(labels), category in present]
+    present_labels = [label for label in labels if all(category -> haskey(group[category], label), present)]
+    isempty(present_labels) && return
+    data = [median_ms(group[category][present_labels[j]]) for j in eachindex(present_labels), category in present]
     groupedbar(present, permutedims(data), bar_position=:dodge,
         legend=:topleft, title=title, xlabel="", ylabel="median time (ms)",
-        label=permutedims(series_label.(labels)))
+        label=permutedims(series_label.(present_labels)))
     png(joinpath(out_dir, outfile))
 end
 
@@ -218,7 +220,7 @@ function main()
         ["default", "wnaf", "glv"], "BN254 G1 scalar GLV sweep", "bn254_glv_scalar_g1.png")
     plot_categorical_group(res, out_dir, :bn254_glv_scalar_g2,
         ["bits_32", "bits_64", "bits_128", "bits_192", "bits_254"],
-        ["default", "glv"], "BN254 G2 scalar GLV sweep", "bn254_glv_scalar_g2.png")
+        ["default", "wnaf", "subgroup_glv", "glv"], "BN254 G2 scalar GLV sweep", "bn254_glv_scalar_g2.png")
     plot_single_ops(res, out_dir, :bn254_curve_kernels,
         ["g1_double", "g1_add", "g1_to_affine", "g2_double", "g2_add", "g2_to_affine"],
         "BN254 curve kernels", "bn254_curve_kernels.png")

--- a/benchmarks/prove_full_common.jl
+++ b/benchmarks/prove_full_common.jl
@@ -298,7 +298,7 @@ function assemble_ab_terms(pk::ProvingKey, A_acc_g1, B_acc_g1, B_acc_g2, r, s)
     A1_g1 = pk.alpha_g1 + A_acc_g1
     B1_g1 = pk.beta_g1 + B_acc_g1
     A = A1_g1 + scalar_mul(pk.delta_g1, r)
-    B = pk.beta_g2 + B_acc_g2 + scalar_mul(pk.delta_g2, s)
+    B = pk.beta_g2 + B_acc_g2 + g2_subgroup_scalar_mul(pk.delta_g2, s)
     return (A = A, B = B, A1_g1 = A1_g1, B1_g1 = B1_g1)
 end
 

--- a/benchmarks/run.jl
+++ b/benchmarks/run.jl
@@ -556,15 +556,15 @@ function bench_scalar_plumbing(results)
     l_msm_bigint = GrothAlgebra.multi_scalar_mul(pk.L_query_g1, priv_scalars_bigint)
     g1_scalar_res_fr = scalar_mul(pk.delta_g1, g1_scalar_fr)
     g1_scalar_res_bigint = scalar_mul(pk.delta_g1, g1_scalar_bigint)
-    g2_scalar_res_fr = scalar_mul(pk.delta_g2, g2_scalar_fr)
-    g2_scalar_res_bigint = scalar_mul(pk.delta_g2, g2_scalar_bigint)
+    g2_scalar_res_fr = GrothCurves.g2_subgroup_scalar_mul(pk.delta_g2, g2_scalar_fr)
+    g2_scalar_res_bigint = GrothCurves.g2_subgroup_scalar_mul(pk.delta_g2, g2_scalar_bigint)
 
     msm_a_fr == msm_a_bigint || error("BN254Fr scalar plumbing changed A-query MSM result")
     msm_b2_fr == msm_b2_bigint || error("BN254Fr scalar plumbing changed B2-query MSM result")
     h_msm_fr == h_msm_bigint || error("BN254Fr scalar plumbing changed H MSM result")
     l_msm_fr == l_msm_bigint || error("BN254Fr scalar plumbing changed L MSM result")
     g1_scalar_res_fr == g1_scalar_res_bigint || error("BN254Fr scalar plumbing changed G1 scalar_mul result")
-    g2_scalar_res_fr == g2_scalar_res_bigint || error("BN254Fr scalar plumbing changed G2 scalar_mul result")
+    g2_scalar_res_fr == g2_scalar_res_bigint || error("BN254Fr scalar plumbing changed G2 subgroup scalar_mul result")
 
     record_semantic!(results, :scalar_plumbing, "g1_scalar_delta", serialize_affine(g1_scalar_res_fr))
     record_semantic!(results, :scalar_plumbing, "g2_scalar_delta", serialize_affine(g2_scalar_res_fr))
@@ -585,12 +585,12 @@ function bench_scalar_plumbing(results)
     record_simple!(results, :scalar_plumbing_g1_scalar, "bigint", tr_g1_bigint)
     record_simple!(results, :scalar_plumbing_g1_scalar, "bn254fr", tr_g1_fr)
 
-    _ = scalar_mul(pk.delta_g2, g2_scalar_bigint)
-    _ = scalar_mul(pk.delta_g2, g2_scalar_fr)
-    tr_g2_bigint = @benchmark scalar_mul($pk.delta_g2, $g2_scalar_bigint) seconds = 1 samples = 10
-    tr_g2_fr = @benchmark scalar_mul($pk.delta_g2, $g2_scalar_fr) seconds = 1 samples = 10
-    print_stats("scalar_plumbing G2 bigint", tr_g2_bigint)
-    print_stats("scalar_plumbing G2 bn254fr", tr_g2_fr)
+    _ = GrothCurves.g2_subgroup_scalar_mul(pk.delta_g2, g2_scalar_bigint)
+    _ = GrothCurves.g2_subgroup_scalar_mul(pk.delta_g2, g2_scalar_fr)
+    tr_g2_bigint = @benchmark GrothCurves.g2_subgroup_scalar_mul($pk.delta_g2, $g2_scalar_bigint) seconds = 1 samples = 10
+    tr_g2_fr = @benchmark GrothCurves.g2_subgroup_scalar_mul($pk.delta_g2, $g2_scalar_fr) seconds = 1 samples = 10
+    print_stats("scalar_plumbing G2 subgroup bigint", tr_g2_bigint)
+    print_stats("scalar_plumbing G2 subgroup bn254fr", tr_g2_fr)
     record_simple!(results, :scalar_plumbing_g2_scalar, "bigint", tr_g2_bigint)
     record_simple!(results, :scalar_plumbing_g2_scalar, "bn254fr", tr_g2_fr)
 
@@ -692,23 +692,26 @@ function bench_glv_scalar_tuning(results)
         bits = GrothAlgebra._bit_length(scalar)
         wnaf_window = GrothAlgebra._scalar_mul_window(G2Point, bits)
         expected = GrothAlgebra.scalar_mul_wnaf(inputs.g2, scalar, wnaf_window)
-        glv = GrothCurves.glv_scalar_mul(inputs.g2, scalar)
+        glv = GrothCurves.g2_subgroup_scalar_mul(inputs.g2, scalar)
         default = scalar_mul(inputs.g2, scalar)
-        expected == glv || error("G2 GLV mismatch for $(label)")
+        expected == glv || error("G2 subgroup GLV mismatch for $(label)")
         expected == default || error("G2 default scalar path mismatch for $(label)")
         record_semantic!(results, :bn254_glv_scalar_g2, label, serialize_affine(glv))
 
         _ = scalar_mul(inputs.g2, scalar)
         _ = GrothAlgebra.scalar_mul_wnaf(inputs.g2, scalar, wnaf_window)
-        _ = GrothCurves.glv_scalar_mul(inputs.g2, scalar)
+        _ = GrothCurves.g2_subgroup_scalar_mul(inputs.g2, scalar)
 
         tr_default = @benchmark scalar_mul($(inputs.g2), $scalar) seconds = 1 samples = 10
-        tr_glv = @benchmark GrothCurves.glv_scalar_mul($(inputs.g2), $scalar) seconds = 1 samples = 10
+        tr_wnaf = @benchmark GrothAlgebra.scalar_mul_wnaf($(inputs.g2), $scalar, $wnaf_window) seconds = 1 samples = 10
+        tr_glv = @benchmark GrothCurves.g2_subgroup_scalar_mul($(inputs.g2), $scalar) seconds = 1 samples = 10
 
         print_stats("G2 $(label) default", tr_default)
-        print_stats("G2 $(label) glv", tr_glv)
+        print_stats("G2 $(label) wnaf", tr_wnaf)
+        print_stats("G2 $(label) subgroup_glv", tr_glv)
         record_result!(results, :bn254_glv_scalar_g2, label, "default", tr_default)
-        record_result!(results, :bn254_glv_scalar_g2, label, "glv", tr_glv)
+        record_result!(results, :bn254_glv_scalar_g2, label, "wnaf", tr_wnaf)
+        record_result!(results, :bn254_glv_scalar_g2, label, "subgroup_glv", tr_glv)
     end
 end
 

--- a/docs/Implementation_vs_Arkworks.md
+++ b/docs/Implementation_vs_Arkworks.md
@@ -22,11 +22,11 @@ Aug 2025 refactor summary:
 
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
-| MSM backend | `VariableBaseMSM` (Straus + endomorphism on BLS curves) | `GrothAlgebra.multi_scalar_mul` now uses a Pippenger-style variable-base backend with a small-input Straus fallback; w-NAF helpers remain shared. Endomorphism optimisations TBD |
+| MSM backend | `VariableBaseMSM` (Straus + endomorphism on BLS curves) | `GrothAlgebra.multi_scalar_mul` now uses a Pippenger-style variable-base backend with a small-input Straus fallback; BN254 G1 has measured GLV dispatch, and G2 exposes GLV through an explicit subgroup-only helper rather than the arbitrary-point default |
 | Fixed-base tables | `FixedBaseMSM` with windowing | `FixedBaseTable` in `GrothAlgebra/src/Group.jl`; setup uses measured BN254 scalar/GLV dispatch for G1 query generation and a fixed-window batch path for the G2 query |
 
-Planned work: evaluate window sizes and endomorphisms once we profile the coset
-prover path.
+Planned work: continue tuning MSM windows and endomorphism use against the real
+`prove_full` fixtures.
 
 ## Curve Abstractions & Pairing Engine
 
@@ -41,7 +41,7 @@ prover path.
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
 | R1CS → QAP | Domain filled completely, IFFT → FFT on coset | Same structure; constraints, public-input selector slots, and zero padding are all explicit before IFFT |
-| Prover/setup | Coset FFT path by default, dense path available for debugging | `prove_full` uses coset-only H computation and combines H/L into one G1 MSM for `C`; `setup_full` uses measured query-generation dispatch; dense/coset parity is kept in explicit debug/test helpers |
+| Prover/setup | Coset FFT path by default, dense path available for debugging | `prove_full` uses coset-only H computation and combines H/L into one G1 MSM for `C`; `setup_full` uses measured query-generation dispatch; subgroup-owned fixed G2 elements use explicit GLV; dense/coset parity is kept in explicit debug/test helpers |
 | Prepared verifier | `PreparedVerifyingKey` with batched pairing | `prepare_verifying_key`, `prepare_inputs`, `verify_with_prepared` mirror arkworks and use the pairing engine |
 | Aggregation | `groth16::aggregate_proofs` available | Not yet ported; on roadmap |
 

--- a/docs/PACKAGE_REFERENCE.md
+++ b/docs/PACKAGE_REFERENCE.md
@@ -55,7 +55,10 @@ annotated rather than discarded), and follow-ups.
 - Projective point abstraction (`ProjectivePoint{Curve,F}`) enables additional
   curve engines in future work.
 - BN254 G1/G2 scalar multiplication now dispatches to tuned w-NAF windows by
-  default; the generic binary fallback remains available for other group types.
+  default; large G1 scalars use measured GLV dispatch. G2 exposes
+  `g2_subgroup_scalar_mul` for points already known to be in the BN254
+  prime-order subgroup, while generic G2 `scalar_mul` remains the safe path for
+  arbitrary on-curve points.
 - (2026-04-01) Stage 4 of the Montgomery roadmap replaced `SVector`-backed
   `Fp2`/`Fp6`/`Fp12` storage with concrete field members and specialized
   nonresidue helpers for `xi = 9 + u` and `v = (0, 1, 0)`. The first Stage 4
@@ -95,6 +98,9 @@ annotated rather than discarded), and follow-ups.
 - (2026-05-11) `setup_full` routes G1 query generation through the BN254 scalar
   dispatcher, whose GLV path beats fixed-base w-NAF for the measured setup
   scalars; the G2 query uses a fixed-window batch path.
+- (2026-05-11) `setup_full` and `prove_full` route subgroup-owned fixed G2
+  elements through the explicit `g2_subgroup_scalar_mul` helper. Verifier
+  subgroup checks intentionally keep the generic G2 scalar path.
 - (2026-04-02) The current follow-through work has shifted from broad backend
   migration to the remaining prover and pairing specialization steps surfaced
   by the Stage 8A baseline.
@@ -148,8 +154,7 @@ annotated rather than discarded), and follow-ups.
 ## Roadmap snapshot (see `ROADMAP.md`)
 
 - Immediate: limb-native inversion, final-exponentiation specialization,
-  extension-field hot paths, safe G2 GLV exposure, and prover-shaped MSM
-  specialization.
+  extension-field hot paths, and prover-shaped MSM specialization.
 - Stretch: proof aggregation, second curve prototype, then Stage 9
   parallelism / accelerators once the single-thread backend is tighter.
 
@@ -171,6 +176,8 @@ annotated rather than discarded), and follow-ups.
 - [x] Coset FFT path default with dense assertion.
 - [x] Align QAP domain population with arkworks.
 - [x] Implement variable-base Pippenger MSM and route prover query MSMs through it.
+- [x] Expose G2 GLV through an explicit subgroup-only helper and route
+  construction-owned Groth16 G2 scalar multiplications through it.
 - [ ] Extend MSM work with fixed-base Pippenger / further setup-side tuning if benchmarks justify it.
 - [ ] Prototype second pairing engine (BLS12-381).
 - [ ] Port proof aggregation.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -72,6 +72,9 @@ an arkworks-aligned, production-friendly Groth16 stack.
 - `setup_full` query generation now uses BN254 G1 scalar/GLV dispatch for G1
   queries and a fixed-window G2 batch path; the generated fixture is now
   `116.918 ms`.
+- G2 GLV is exposed through an explicit subgroup-only helper. Groth16
+  setup/proving use it for construction-owned G2 key points, while verifier
+  subgroup checks keep generic G2 scalar multiplication for arbitrary input.
 - Prepared verifier matches arkworks (batched pairing path).
 - Benchmarks expanded (pairing & Groth16 hot paths with JSON/PNG artefacts).
 - Groth16 tests cover multiple circuits, randomized seeds, prepared-path

--- a/docs/src/algebra.md
+++ b/docs/src/algebra.md
@@ -28,7 +28,7 @@ Depth = 2
 - FFT helpers guard against silent truncation and support the full-domain QAP
   interpolation path used by Groth16.
 - FFT helpers now gate the dense fallback behind parity assertions.
-- BN254 `scalar_mul` now selects tuned w-NAF windows for G1/G2, while other group types keep the generic fallback.
+- BN254 `scalar_mul` now selects tuned w-NAF windows for G1/G2, while other group types keep the generic fallback. Large G1 scalars use measured GLV dispatch; G2 GLV is exposed separately for subgroup-owned points.
 
 ## Follow-ups
 

--- a/docs/src/assets/g2_subgroup_glv_tuning_2026_05_11.json
+++ b/docs/src/assets/g2_subgroup_glv_tuning_2026_05_11.json
@@ -1,0 +1,77 @@
+{
+  "summary": "Safe G2 GLV exposure: Groth16 setup/proving now use an explicit subgroup-only G2 GLV helper for construction-owned key points, while generic G2 scalar multiplication remains the safe arbitrary-point default.",
+  "candidate_run_id": "2026-05-11_190310",
+  "benchmark_profile": "custom",
+  "benchmark_groups": [
+    "glv_scalar_tuning",
+    "scalar_plumbing",
+    "setup_full",
+    "prove_full"
+  ],
+  "julia_version": "1.12.6",
+  "threadpools": {
+    "default": 24,
+    "interactive": 1
+  },
+  "cpu": "znver5",
+  "g2_scalar_sweep": {
+    "bits_32": {
+      "default_median_ms": 0.334726,
+      "wnaf_median_ms": 0.314399,
+      "subgroup_glv_median_ms": 0.334892
+    },
+    "bits_64": {
+      "default_median_ms": 0.525459,
+      "wnaf_median_ms": 0.529532,
+      "subgroup_glv_median_ms": 0.554383
+    },
+    "bits_128": {
+      "default_median_ms": 1.014,
+      "wnaf_median_ms": 1.072,
+      "subgroup_glv_median_ms": 1.504
+    },
+    "bits_192": {
+      "default_median_ms": 1.544,
+      "wnaf_median_ms": 1.632,
+      "subgroup_glv_median_ms": 1.609
+    },
+    "bits_254": {
+      "default_median_ms": 2.455,
+      "wnaf_median_ms": 2.44,
+      "subgroup_glv_median_ms": 1.612,
+      "subgroup_glv_speedup_vs_default": "1.52x",
+      "subgroup_glv_memory_bytes": 1241864,
+      "default_memory_bytes": 1943968
+    }
+  },
+  "scalar_plumbing": {
+    "g2_subgroup_scalar_bigint_median_ms": 1.537,
+    "g2_subgroup_scalar_bn254fr_median_ms": 1.549,
+    "previous_g2_scalar_bn254fr_median_ms": 2.355,
+    "relative_to_previous_g2_scalar_bn254fr": "-34.22%"
+  },
+  "fixtures": {
+    "sum_of_products_small": {
+      "constraints": 3,
+      "public_inputs": 6,
+      "domain_size": 16,
+      "setup_full_median_ms": 42.992,
+      "prove_full_median_ms": 10.658
+    },
+    "generated_24_constraints": {
+      "constraints": 24,
+      "public_inputs": 8,
+      "domain_size": 32,
+      "setup_full_median_ms": 118.747,
+      "prove_full_median_ms": 27.659,
+      "b2_msm_median_ms": 4.286,
+      "final_c_median_ms": 2.175
+    }
+  },
+  "notes": [
+    "The generic G2 scalar path intentionally remains w-NAF so verifier subgroup checks stay valid for arbitrary on-curve input.",
+    "The subgroup GLV helper is only safe when the caller already knows the point is in G2[r].",
+    "The scalar sweep shows subgroup GLV is most useful for full-width scalars; Groth16 setup/prover randomizers are full-width except for rare zero draws handled by the helper.",
+    "The setup/prove fixture medians are close enough to prior same-day runs that the main conclusion is safe exposure and scalar-path improvement, not a new end-to-end prover claim."
+  ]
+}

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -309,6 +309,35 @@ while the G2 query uses a wider fixed-window batch path. The generated fixture
 is again the better continuity signal because it exercises a larger set of
 query scalars.
 
+## Safe G2 Subgroup GLV Snapshot (2026-05-11)
+
+The safe G2 GLV exposure artifact is:
+
+- tracked summary:
+  `docs/src/assets/g2_subgroup_glv_tuning_2026_05_11.json`
+- local full artifact:
+  `benchmarks/artifacts/2026-05-11_190310/results/benchmark_results.json`
+
+This run keeps generic G2 `scalar_mul` on the arbitrary-point w-NAF path and
+measures the explicit subgroup-only GLV helper separately. Groth16 setup/proving
+use the helper only for G2 key points whose subgroup ownership follows from
+construction.
+
+| Scalar bits | G2 default | G2 w-NAF | G2 subgroup GLV |
+| --- | ---: | ---: | ---: |
+| `32` | `0.335 ms` | `0.314 ms` | `0.335 ms` |
+| `64` | `0.525 ms` | `0.530 ms` | `0.554 ms` |
+| `128` | `1.014 ms` | `1.072 ms` | `1.504 ms` |
+| `192` | `1.544 ms` | `1.632 ms` | `1.609 ms` |
+| `254` | `2.455 ms` | `2.440 ms` | `1.612 ms` |
+
+Interpretation: the explicit G2 GLV path is not a universal scalar-mul default;
+it is useful for the full-width subgroup-owned scalars used by setup/proving.
+The `scalar_plumbing` fixture reported `g2_subgroup_scalar_mul(delta_g2, s)` at
+`1.549 ms` for `BN254Fr`, versus `2.355 ms` for the earlier generic G2 scalar
+path in the Stage 8A notes. Verifier subgroup checks still use generic G2 scalar
+multiplication because proof inputs are untrusted.
+
 ## Latest Snapshot (2025‑09‑29)
 
 ```@example

--- a/docs/src/curves.md
+++ b/docs/src/curves.md
@@ -25,6 +25,9 @@ Depth = 2
 
 - Sparse Fp12 placement and Frobenius corrections follow standard BN254 references.
 - `ProjectivePoint{Curve,F}` keeps the pairing engine generic so future curves can reuse the pipeline.
+- `g2_subgroup_scalar_mul` exposes BN254 G2 GLV acceleration only for points
+  already known to be in the prime-order subgroup. Generic `scalar_mul` remains
+  the safe scalar path for arbitrary G2 points.
 
 ## Follow-ups
 
@@ -48,6 +51,7 @@ ProjectivePoint
 GrothCurves.doubling_step
 GrothCurves.addition_step
 GrothCurves.evaluate_line
+GrothCurves.g2_subgroup_scalar_mul
 ```
 
 ### Example

--- a/docs/src/implementation-vs-arkworks.md
+++ b/docs/src/implementation-vs-arkworks.md
@@ -27,12 +27,11 @@ Depth = 2
 
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
-| Variable-base MSM | Straus / Pippenger variants with endomorphism support where safe. | `GrothAlgebra.multi_scalar_mul` uses a Pippenger-style backend with a small-input Straus fallback; BN254 G1 now has a measured hybrid GLV path, and G2 has an internal GLV path that is not yet the unconditional public default. |
+| Variable-base MSM | Straus / Pippenger variants with endomorphism support where safe. | `GrothAlgebra.multi_scalar_mul` uses a Pippenger-style backend with a small-input Straus fallback; BN254 G1 now has a measured hybrid GLV path, and G2 exposes GLV through an explicit subgroup-only helper rather than the arbitrary-point default. |
 | Fixed-base tables | `FixedBaseMSM` window tables. | `FixedBaseTable` plus `build_fixed_table`, `mul_fixed`, and `batch_mul` mirror the workflow; setup uses measured BN254 scalar/GLV dispatch for G1 query generation and a fixed-window batch path for the G2 query. |
 
-**Next steps:** keep MSM work tied to the real `prove_full` fixtures, pursue
-safe G2 GLV exposure, and avoid treating synthetic MSM sweeps as the sole
-tuning signal.
+**Next steps:** keep MSM work tied to the real `prove_full` fixtures and avoid
+treating synthetic MSM sweeps as the sole tuning signal.
 
 ## Curve Abstractions & Pairing Engine
 
@@ -47,7 +46,7 @@ tuning signal.
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
 | R1CS → QAP | Domain fully populated, IFFT then FFT on the coset. | Same structure; constraints, public-input selector slots, and zero padding are all explicit before IFFT. |
-| Prover/setup | Coset FFT path, dense available for debugging. | `prove_full` uses coset-only H computation and combines H/L into one G1 MSM for `C`; `setup_full` uses measured query-generation dispatch; dense/coset parity is kept in explicit debug/test helpers. |
+| Prover/setup | Coset FFT path, dense available for debugging. | `prove_full` uses coset-only H computation and combines H/L into one G1 MSM for `C`; `setup_full` uses measured query-generation dispatch; subgroup-owned fixed G2 elements use explicit GLV; dense/coset parity is kept in explicit debug/test helpers. |
 | Prepared verifier | `PreparedVerifyingKey` batches pairings. | `prepare_verifying_key`, `prepare_inputs`, and `verify_with_prepared` mirror the API. |
 | Aggregation | Optional `groth16::aggregate_proofs`. | Not yet ported; tracked on the roadmap. |
 
@@ -56,7 +55,6 @@ tuning signal.
 1. Replace the remaining `BigInt`-based inversion path in the BN254 Montgomery backend.
 2. Specialize final exponentiation further around cyclotomic operations and measured BN254 structure.
 3. Reduce value churn in extension-field hot paths where the current pairing code is still less in-place than arkworks.
-4. Find a safe way to expose G2 GLV acceleration on subgroup-owned points without weakening public semantics.
-5. Rebaseline `prove_full` after each high-leverage specialization stage instead of batching changes together.
+4. Rebaseline `prove_full` after each high-leverage specialization stage instead of batching changes together.
 
 Use this page as a checklist whenever behaviour changes—update the tables above as new features land.

--- a/docs/src/proofs.md
+++ b/docs/src/proofs.md
@@ -29,6 +29,9 @@ Depth = 2
   proof element, since the algebra only needs their sum.
 - `setup_full` uses the measured BN254 G1 scalar/GLV path for G1 query
   generation and a fixed-window batch path for the G2 query.
+- Fixed G2 key elements and the prover `delta_g2` randomizer term use the
+  explicit subgroup-only G2 GLV helper. Verification subgroup checks still use
+  generic G2 scalar multiplication because proof inputs are untrusted.
 - QAP conversion uses an arkworks-shaped full domain: constraints first,
   public-input selector rows next, zero padding last, and `t(x) = x^N - 1`.
 - The latest prover optimization work is now focused on the remaining


### PR DESCRIPTION
## Summary
- add explicit `g2_subgroup_scalar_mul` for BN254 G2 points already known to be in the prime-order subgroup
- route Groth16 setup/proving subgroup-owned G2 scalar multiplications through the helper while leaving generic G2 `scalar_mul` unchanged for arbitrary verifier input
- update tests, benchmark labels/plots, docs, and tracked benchmark summary

## Validation
- `Pkg.test("GrothCurves")`
- `Pkg.test("GrothProofs")`
- `include("scripts/test_all.jl")`
- docs build: `include("make.jl")` from `docs/`

## Benchmarks
- focused run: `benchmarks/artifacts/2026-05-11_190310/results/benchmark_results.json`
- groups: `glv_scalar_tuning,scalar_plumbing,setup_full,prove_full`
- full-width G2 subgroup GLV: `1.612 ms` vs generic default `2.455 ms`
- `g2_subgroup_scalar_mul(delta_g2, s)` with `BN254Fr`: `1.549 ms`