### PR TITLE
groth16: route h/l msm through g1 glv

### DIFF
--- a/GrothCurves/src/BN254Curve.jl
+++ b/GrothCurves/src/BN254Curve.jl
@@ -248,6 +248,75 @@ default for arbitrary on-curve points, including verifier subgroup checks.
 g2_subgroup_scalar_mul(p::G2Point, k::Integer) = glv_scalar_mul(p, k)
 g2_subgroup_scalar_mul(p::G2Point, k::GrothAlgebra.BN254Fr) = glv_scalar_mul(p, k)
 
+@inline _g1_glv_scalar_bigint(k::Integer) = BigInt(k)
+@inline _g1_glv_scalar_bigint(k::GrothAlgebra.BN254Fr) = _bn254fr_scalar_bigint(k)
+
+function _append_g1_glv_terms!(out_points::Vector{G1Point}, out_scalars::Vector{BigInt}, p::G1Point, scalar)
+    ((sgn_k1, k1), (sgn_k2, k2)) = glv_scalar_decomposition(G1Point, _g1_glv_scalar_bigint(scalar))
+
+    if !iszero(k1)
+        push!(out_points, p)
+        push!(out_scalars, sgn_k1 ? k1 : -k1)
+    end
+
+    if !iszero(k2)
+        push!(out_points, glv_endomorphism(p))
+        push!(out_scalars, sgn_k2 ? k2 : -k2)
+    end
+
+    return nothing
+end
+
+"""
+    g1_subgroup_multi_scalar_mul(points::Vector{G1Point}, scalars::Vector)
+
+Compute `sum(scalars[i] * points[i])` with BN254 G1 GLV decomposition,
+assuming every point is already in the prime-order G1 subgroup.
+
+This helper keeps the GLV-MSM precondition explicit; the generic
+`GrothAlgebra.multi_scalar_mul` API remains the arbitrary-group default.
+"""
+function g1_subgroup_multi_scalar_mul(points::Vector{G1Point}, scalars::Vector{S}) where {S}
+    length(points) == length(scalars) || throw(ArgumentError("Points and scalars must have the same length"))
+    isempty(points) && throw(ArgumentError("Cannot compute multi-scalar multiplication of empty vectors"))
+
+    if length(points) == 1
+        return GrothAlgebra.scalar_mul(points[1], scalars[1])
+    end
+
+    glv_points = G1Point[]
+    glv_scalars = BigInt[]
+    sizehint!(glv_points, 2 * length(points))
+    sizehint!(glv_scalars, 2 * length(scalars))
+
+    @inbounds for i in eachindex(points, scalars)
+        _append_g1_glv_terms!(glv_points, glv_scalars, points[i], scalars[i])
+    end
+
+    isempty(glv_points) && return zero(points[1])
+    return GrothAlgebra.multi_scalar_mul(glv_points, glv_scalars)
+end
+
+"""
+    g1_subgroup_multi_scalar_mul_pair(points_a::Vector{G1Point}, points_b::Vector{G1Point}, scalars::Vector)
+
+Compute two BN254 G1 GLV-MSMs over the same scalar vector. This helper is
+intended for subgroup-owned CRS/query points; it preserves the generic MSM API
+for arbitrary group elements.
+"""
+function g1_subgroup_multi_scalar_mul_pair(points_a::Vector{G1Point}, points_b::Vector{G1Point}, scalars::Vector{S}) where {S}
+    if length(points_a) != length(points_b) || length(points_a) != length(scalars)
+        throw(ArgumentError("Point and scalar vectors must have the same length"))
+    end
+
+    isempty(points_a) && throw(ArgumentError("Cannot compute multi-scalar multiplication of empty vectors"))
+
+    return (
+        g1_subgroup_multi_scalar_mul(points_a, scalars),
+        g1_subgroup_multi_scalar_mul(points_b, scalars),
+    )
+end
+
 """
     GrothAlgebra.scalar_mul(p::G1Point, k::Integer)
     GrothAlgebra.scalar_mul(p::G1Point, k::GrothAlgebra.BN254Fr)

--- a/GrothCurves/src/GrothCurves.jl
+++ b/GrothCurves/src/GrothCurves.jl
@@ -38,6 +38,7 @@ export Fp6Element, Fp12Element, GTElement, square
 export BN254Curve, G1Point, G2Point, BN254Engine, BN254_ENGINE
 export to_affine, is_on_curve, double, batch_to_affine!
 export g1_generator, g2_generator
+export g1_subgroup_multi_scalar_mul, g1_subgroup_multi_scalar_mul_pair
 export g2_subgroup_scalar_mul
 export x_coord, y_coord, z_coord
 export LineCoeffs, doubling_step, addition_step, evaluate_line, miller_loop, frobenius_g2

--- a/GrothCurves/test/test_bn254_curve.jl
+++ b/GrothCurves/test/test_bn254_curve.jl
@@ -472,6 +472,42 @@ glv_component_bits(component::Tuple{Bool,BigInt}) = iszero(component[2]) ? 0 : n
             @test pair_a == multi_scalar_mul(prover_points, prover_scalars)
             @test pair_b == multi_scalar_mul(prover_points_b, prover_scalars)
         end
+
+        @testset "G1 subgroup GLV MSM helpers match generic MSM" begin
+            g1 = g1_generator()
+            points = [scalar_mul(g1, benchmark_scalar(800 + i)) for i in 1:12]
+            scalars_fr = [
+                bn254_fr(0),
+                bn254_fr(1),
+                bn254_fr(2),
+                bn254_fr(3),
+                bn254_fr(benchmark_scalar(821)),
+                bn254_fr(benchmark_scalar(822)),
+                bn254_fr(benchmark_scalar(823)),
+                bn254_fr(benchmark_scalar(824)),
+                bn254_fr(GrothCurves.BN254_ORDER_R - 12345),
+                bn254_fr(GrothCurves.BN254_ORDER_R - 67890),
+                bn254_fr(17),
+                bn254_fr(31),
+            ]
+            scalars_bigint = map(x -> convert(BigInt, x), scalars_fr)
+
+            @test g1_subgroup_multi_scalar_mul(points, scalars_fr) ==
+                  multi_scalar_mul(points, scalars_fr)
+            @test g1_subgroup_multi_scalar_mul(points, scalars_bigint) ==
+                  multi_scalar_mul(points, scalars_bigint)
+
+            points_b = [scalar_mul(g1, benchmark_scalar(900 + i)) for i in 1:12]
+            pair_a, pair_b = g1_subgroup_multi_scalar_mul_pair(points, points_b, scalars_fr)
+            @test pair_a == multi_scalar_mul(points, scalars_fr)
+            @test pair_b == multi_scalar_mul(points_b, scalars_fr)
+
+            @test g1_subgroup_multi_scalar_mul([points[1]], [scalars_fr[5]]) ==
+                  scalar_mul(points[1], scalars_fr[5])
+            @test_throws ArgumentError g1_subgroup_multi_scalar_mul(G1Point[], BN254Fr[])
+            @test_throws ArgumentError g1_subgroup_multi_scalar_mul(points, scalars_fr[1:3])
+            @test_throws ArgumentError g1_subgroup_multi_scalar_mul_pair(points, points_b[1:3], scalars_fr)
+        end
     end
     
     @testset "Fp2 Field Operations" begin

--- a/GrothProofs/src/Groth16.jl
+++ b/GrothProofs/src/Groth16.jl
@@ -266,9 +266,9 @@ function prove_full(pk::ProvingKey, qap::QAP{F}, witness::Witness{F}; rng::Abstr
         copyto!(pts_hl, hk + 1, pk.L_query_g1, 1, length(priv_scalars))
         copyto!(scalars_hl, 1, scalars_h, 1, hk)
         copyto!(scalars_hl, hk + 1, priv_scalars, 1, length(priv_scalars))
-        HL = GrothAlgebra.multi_scalar_mul(pts_hl, scalars_hl)
+        HL = g1_subgroup_multi_scalar_mul(pts_hl, scalars_hl)
     else
-        HL = GrothAlgebra.multi_scalar_mul(pts_h, scalars_h)
+        HL = g1_subgroup_multi_scalar_mul(pts_h, scalars_h)
     end
 
     # Cross terms in C. This is algebraically equivalent to

--- a/README.md
+++ b/README.md
@@ -43,12 +43,17 @@ The project has moved well beyond a minimal Groth16 demo.
 - The gap to arkworks has narrowed substantially, but arkworks is still ahead.
 - QAP conversion now follows the arkworks domain shape: constraints first,
   public-input selector rows next, and zero padding to the next power of two.
-- The current larger deterministic `prove_full` baseline after QAP domain
+- The QAP-domain-aligned larger deterministic `prove_full` baseline after
   alignment, coset-only H proving, and H/L MSM fusion is `26.643 ms` in the
   tracked summary
   [docs/src/assets/prove_full_msm_tuning_2026_05_11.json](./docs/src/assets/prove_full_msm_tuning_2026_05_11.json),
   down from the original `136.187 ms` baseline captured at the start of the
   performance investigation.
+- The latest G1 GLV-MSM prover pass routes the combined H/L query MSM through
+  an explicit subgroup-owned helper. On the generated fixture, that phase moved
+  from `11.907 ms` to `9.647 ms`; end-to-end `prove_full` stayed essentially
+  flat at `27.626 ms` in
+  [docs/src/assets/g1_glv_msm_tuning_2026_05_11.json](./docs/src/assets/g1_glv_msm_tuning_2026_05_11.json).
 - The current larger deterministic `setup_full` fixture is `116.918 ms` in
   [docs/src/assets/setup_full_tuning_2026_05_11.json](./docs/src/assets/setup_full_tuning_2026_05_11.json),
   down from the `142.715 ms` pre-change baseline on the same fixture.
@@ -161,16 +166,17 @@ These are primitive-level measurements, not end-to-end Groth16 prover
 comparisons.
 
 Latest tracked `prove_full` prover fixture summary
-(`2026-05-11_165756`, Stage 8 profile):
+(`2026-05-11_193033`, G1 GLV-MSM focused profile):
 
 | Fixture | Domain | `prove_full` | Key prover phases |
 | --- | ---: | ---: | --- |
-| `sum_of_products_small` | `16` | `10.943 ms` | H+L MSM `5.619 ms`, final C `2.133 ms` |
-| `generated_24_constraints` | `32` | `26.643 ms` | H+L MSM `11.029 ms`, final C `2.140 ms` |
+| `sum_of_products_small` | `16` | `11.594 ms` | H+L MSM `4.924 ms`, final C `2.444 ms` |
+| `generated_24_constraints` | `32` | `27.626 ms` | H+L MSM `9.647 ms`, final C `2.488 ms` |
 
-The generated fixture improved from `28.636 ms` to `26.643 ms` versus the
-previous coset-only H baseline by combining the separate H and L G1 MSMs into
-one MSM for the `C` proof element.
+The current production H/L MSM uses explicit BN254 G1 GLV decomposition on
+subgroup-owned CRS points. In the generated fixture it was `18.98%` faster than
+the generic H/L MSM measured in the same run; the end-to-end prover movement is
+small enough that we treat it as flat rather than a headline speedup.
 
 Latest tracked `setup_full` fixture summary
 (`2026-05-11_175228`, setup profile):

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -403,6 +403,28 @@ already known to be in `G2[r]`. Groth16 setup/proving uses it for fixed G2 key
 points constructed from the generator; verifier subgroup checks keep generic
 G2 scalar multiplication for arbitrary proof input.
 
+## G1 GLV-MSM Prover Snapshot (2026-05-11)
+
+- Focused run:
+  `artifacts/2026-05-11_193033/results/benchmark_results.json`
+- Tracked summary:
+  `../docs/src/assets/g1_glv_msm_tuning_2026_05_11.json`
+
+The prover now routes the combined H/L G1 MSM through explicit subgroup-owned
+GLV decomposition. A quick A/B1 pair check did not improve, so that bucket stays
+on the existing fused pair MSM.
+
+| Fixture | Generic H/L MSM | G1 GLV H/L MSM | Phase change | `prove_full` |
+| --- | ---: | ---: | ---: | ---: |
+| `sum_of_products_small` | `6.642 ms` | `4.924 ms` | `-25.87%` | `11.594 ms` |
+| `generated_24_constraints` | `11.907 ms` | `9.647 ms` | `-18.98%` | `27.626 ms` |
+
+The generated fixture H/L query has `51` original bases and expands to `90` GLV
+terms with `127`-bit maximum components. Treat this as a clear H/L phase win
+with essentially flat end-to-end prover movement; the helper still uses
+`BigInt` decomposition, so limb-native GLV decomposition is the natural next
+follow-through.
+
 Generate a full report (run -> plot -> compare) for latest run:
 
 ```

--- a/benchmarks/plot.jl
+++ b/benchmarks/plot.jl
@@ -11,6 +11,7 @@ const PROVE_FULL_PHASE_ORDER = [
     "witness_to_scalars",
     "msm_a_g1",
     "msm_b_g1",
+    "msm_a_b1_g1",
     "msm_b_g2",
     "compute_h_total",
     "h_poly_assembly",
@@ -19,6 +20,8 @@ const PROVE_FULL_PHASE_ORDER = [
     "h_parity_assert",
     "h_msm",
     "l_msm",
+    "h_l_msm_generic",
+    "h_l_msm",
     "final_c",
 ]
 

--- a/benchmarks/prove_full_common.jl
+++ b/benchmarks/prove_full_common.jl
@@ -17,6 +17,7 @@ const PROVE_FULL_PHASE_ORDER = [
     "h_parity_assert",
     "h_msm",
     "l_msm",
+    "h_l_msm_generic",
     "h_l_msm",
     "final_c",
 ]
@@ -177,7 +178,11 @@ function fixture_metadata(fixture)
             "b_query_g2" => msm_selection_metadata(pk.B_query_g2, witness.values),
             "h_query_g1" => msm_selection_metadata(pk.H_query_g1[1:length(h_poly.coeffs)], h_poly.coeffs),
             "l_query_g1" => msm_selection_metadata(pk.L_query_g1, witness.values[(pk.num_public + 1):end]),
-            "h_l_query_g1" => msm_selection_metadata(
+            "h_l_query_g1_generic" => msm_selection_metadata(
+                vcat(pk.H_query_g1[1:length(h_poly.coeffs)], pk.L_query_g1),
+                vcat(h_poly.coeffs, witness.values[(pk.num_public + 1):end]),
+            ),
+            "h_l_query_g1" => g1_glv_msm_selection_metadata(
                 vcat(pk.H_query_g1[1:length(h_poly.coeffs)], pk.L_query_g1),
                 vcat(h_poly.coeffs, witness.values[(pk.num_public + 1):end]),
             ),
@@ -208,6 +213,35 @@ function msm_selection_metadata(points::AbstractVector, scalars::AbstractVector{
         "nonzero_scalars" => stats.nonzero_count,
         "compact_scalars" => stats.compact_scalar_count,
         "max_scalar_bits" => stats.max_bits,
+        "selected" => selected,
+    )
+end
+
+function g1_glv_msm_selection_metadata(points::AbstractVector{G1Point}, scalars::AbstractVector{BN254Fr})
+    expanded_size = 0
+    max_bits = 0
+    nonzero_scalars = 0
+    @inbounds for scalar in scalars
+        ((_, k1), (_, k2)) = GrothCurves.glv_scalar_decomposition(G1Point, convert(BigInt, scalar))
+        if !iszero(k1)
+            expanded_size += 1
+            max_bits = max(max_bits, GrothAlgebra._bit_length(k1))
+        end
+        if !iszero(k2)
+            expanded_size += 1
+            max_bits = max(max_bits, GrothAlgebra._bit_length(k2))
+        end
+        nonzero_scalars += Int(!(iszero(k1) && iszero(k2)))
+    end
+
+    selected = expanded_size <= 1 ? "scalar_mul" :
+        GrothAlgebra._use_straus_msm(expanded_size, max_bits) ? "straus" :
+        "g1_glv_pippenger_w$(GrothAlgebra._pippenger_window(G1Point, expanded_size))"
+    return Dict{String,Any}(
+        "size" => length(points),
+        "expanded_size" => expanded_size,
+        "nonzero_scalars" => nonzero_scalars,
+        "max_scalar_bits" => max_bits,
         "selected" => selected,
     )
 end
@@ -318,6 +352,24 @@ function l_msm(pk::ProvingKey, witness::Witness)
 end
 
 function h_l_msm(pk::ProvingKey, h_poly, witness::Witness)
+    hk = length(h_poly.coeffs)
+    pts_h = pk.H_query_g1[1:hk]
+    m = length(witness.values)
+    if m <= pk.num_public
+        return GrothCurves.g1_subgroup_multi_scalar_mul(pts_h, h_poly.coeffs)
+    end
+    priv_scalars = witness.values[(pk.num_public+1):m]
+    hl_len = hk + length(priv_scalars)
+    pts_hl = Vector{G1Point}(undef, hl_len)
+    scalars_hl = Vector{eltype(h_poly.coeffs)}(undef, hl_len)
+    copyto!(pts_hl, 1, pts_h, 1, hk)
+    copyto!(pts_hl, hk + 1, pk.L_query_g1, 1, length(priv_scalars))
+    copyto!(scalars_hl, 1, h_poly.coeffs, 1, hk)
+    copyto!(scalars_hl, hk + 1, priv_scalars, 1, length(priv_scalars))
+    return GrothCurves.g1_subgroup_multi_scalar_mul(pts_hl, scalars_hl)
+end
+
+function h_l_msm_generic(pk::ProvingKey, h_poly, witness::Witness)
     hk = length(h_poly.coeffs)
     pts_h = pk.H_query_g1[1:hk]
     m = length(witness.values)

--- a/benchmarks/run.jl
+++ b/benchmarks/run.jl
@@ -1435,6 +1435,11 @@ function bench_prove_full(results)
         print_stats("prove_full[$(name)] L_msm", tr_l_msm)
         record_fixture_trial!(results, :prove_full, name, "l_msm", tr_l_msm)
 
+        _ = h_l_msm_generic(pk, h_poly, witness)
+        tr_h_l_msm_generic = @benchmark h_l_msm_generic($pk, $h_poly, $witness) seconds = 1 samples = 10
+        print_stats("prove_full[$(name)] H+L_msm_generic", tr_h_l_msm_generic)
+        record_fixture_trial!(results, :prove_full, name, "h_l_msm_generic", tr_h_l_msm_generic)
+
         _ = h_l_msm(pk, h_poly, witness)
         tr_h_l_msm = @benchmark h_l_msm($pk, $h_poly, $witness) seconds = 1 samples = 10
         print_stats("prove_full[$(name)] H+L_msm", tr_h_l_msm)

--- a/docs/Implementation_vs_Arkworks.md
+++ b/docs/Implementation_vs_Arkworks.md
@@ -22,7 +22,7 @@ Aug 2025 refactor summary:
 
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
-| MSM backend | `VariableBaseMSM` (Straus + endomorphism on BLS curves) | `GrothAlgebra.multi_scalar_mul` now uses a Pippenger-style variable-base backend with a small-input Straus fallback; BN254 G1 has measured GLV dispatch, and G2 exposes GLV through an explicit subgroup-only helper rather than the arbitrary-point default |
+| MSM backend | `VariableBaseMSM` (Straus + endomorphism on BLS curves) | `GrothAlgebra.multi_scalar_mul` now uses a Pippenger-style variable-base backend with a small-input Straus fallback; BN254 G1 has measured scalar GLV plus an explicit subgroup-owned GLV-MSM helper for the prover H/L query, and G2 exposes scalar GLV through an explicit subgroup-only helper rather than the arbitrary-point default |
 | Fixed-base tables | `FixedBaseMSM` with windowing | `FixedBaseTable` in `GrothAlgebra/src/Group.jl`; setup uses measured BN254 scalar/GLV dispatch for G1 query generation and a fixed-window batch path for the G2 query |
 
 Planned work: continue tuning MSM windows and endomorphism use against the real
@@ -41,7 +41,7 @@ Planned work: continue tuning MSM windows and endomorphism use against the real
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
 | R1CS → QAP | Domain filled completely, IFFT → FFT on coset | Same structure; constraints, public-input selector slots, and zero padding are all explicit before IFFT |
-| Prover/setup | Coset FFT path by default, dense path available for debugging | `prove_full` uses coset-only H computation and combines H/L into one G1 MSM for `C`; `setup_full` uses measured query-generation dispatch; subgroup-owned fixed G2 elements use explicit GLV; dense/coset parity is kept in explicit debug/test helpers |
+| Prover/setup | Coset FFT path by default, dense path available for debugging | `prove_full` uses coset-only H computation and combines H/L into one subgroup-owned G1 GLV-MSM for `C`; `setup_full` uses measured query-generation dispatch; subgroup-owned fixed G2 elements use explicit GLV; dense/coset parity is kept in explicit debug/test helpers |
 | Prepared verifier | `PreparedVerifyingKey` with batched pairing | `prepare_verifying_key`, `prepare_inputs`, `verify_with_prepared` mirror arkworks and use the pairing engine |
 | Aggregation | `groth16::aggregate_proofs` available | Not yet ported; on roadmap |
 

--- a/docs/PACKAGE_REFERENCE.md
+++ b/docs/PACKAGE_REFERENCE.md
@@ -95,6 +95,10 @@ annotated rather than discarded), and follow-ups.
 - (2026-05-11) The prover combines the H and private-variable L contributions
   into one G1 MSM for the `C` proof element, preserving the same `H + L`
   algebra while reducing prover-shaped MSM work on the deterministic fixture.
+- (2026-05-11) The combined H/L G1 MSM now uses an explicit BN254 G1 subgroup
+  GLV-MSM helper. The generated fixture's H/L phase measured `9.647 ms` versus
+  `11.907 ms` for the generic MSM in the same run; end-to-end `prove_full`
+  remained essentially flat at `27.626 ms`.
 - (2026-05-11) `setup_full` routes G1 query generation through the BN254 scalar
   dispatcher, whose GLV path beats fixed-base w-NAF for the measured setup
   scalars; the G2 query uses a fixed-window batch path.
@@ -140,6 +144,10 @@ annotated rather than discarded), and follow-ups.
   `generated_24_constraints` fixture reports `prove_full` at `26.643 ms`,
   `compute_h_total` at `1.481 ms`, `h_msm` at `8.726 ms`, `l_msm` at
   `3.871 ms`, `h_l_msm` at `11.029 ms`, and `final_c` at `2.140 ms`.
+- Latest G1 GLV-MSM prover artifact: `benchmarks/artifacts/2026-05-11_193033`,
+  with tracked summary `docs/src/assets/g1_glv_msm_tuning_2026_05_11.json`.
+  The `generated_24_constraints` fixture reports `prove_full` at `27.626 ms`,
+  generic H/L MSM at `11.907 ms`, and G1 GLV H/L MSM at `9.647 ms`.
 - Latest setup-focused artifact: `benchmarks/artifacts/2026-05-11_175228`,
   with tracked summary `docs/src/assets/setup_full_tuning_2026_05_11.json`.
   The `generated_24_constraints` fixture reports `setup_full` at `116.918 ms`,
@@ -178,6 +186,8 @@ annotated rather than discarded), and follow-ups.
 - [x] Implement variable-base Pippenger MSM and route prover query MSMs through it.
 - [x] Expose G2 GLV through an explicit subgroup-only helper and route
   construction-owned Groth16 G2 scalar multiplications through it.
+- [x] Route the combined prover H/L G1 MSM through explicit subgroup-owned GLV
+  after benchmark validation.
 - [ ] Extend MSM work with fixed-base Pippenger / further setup-side tuning if benchmarks justify it.
 - [ ] Prototype second pairing engine (BLS12-381).
 - [ ] Port proof aggregation.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,6 +69,10 @@ an arkworks-aligned, production-friendly Groth16 stack.
 - `prove_full` combines the H and private-variable L contributions into one G1
   MSM for the `C` proof element; the Stage 8 generated fixture is now
   `26.643 ms`.
+- The combined H/L G1 prover MSM now uses explicit subgroup-owned GLV. The
+  generated fixture measured `9.647 ms` for the H/L phase versus `11.907 ms`
+  for the generic MSM in the same run, with end-to-end proving essentially
+  flat at `27.626 ms`.
 - `setup_full` query generation now uses BN254 G1 scalar/GLV dispatch for G1
   queries and a fixed-window G2 batch path; the generated fixture is now
   `116.918 ms`.

--- a/docs/src/assets/g1_glv_msm_tuning_2026_05_11.json
+++ b/docs/src/assets/g1_glv_msm_tuning_2026_05_11.json
@@ -1,0 +1,48 @@
+{
+  "summary": "G1 GLV-MSM prover tuning: the combined H/L prover MSM now uses an explicit BN254 G1 subgroup GLV-MSM helper. The phase improves clearly, while full prove_full movement is modest and benchmark-noise sensitive.",
+  "candidate_run_id": "2026-05-11_193033",
+  "previous_run_id": "2026-05-11_190310",
+  "benchmark_profile": "custom",
+  "benchmark_groups": [
+    "prove_full"
+  ],
+  "julia_version": "1.12.6",
+  "threadpools": {
+    "default": 24,
+    "interactive": 1
+  },
+  "cpu": "znver5",
+  "fixtures": {
+    "sum_of_products_small": {
+      "constraints": 3,
+      "public_inputs": 6,
+      "domain_size": 16,
+      "prove_full_median_ms": 11.594,
+      "h_l_msm_generic_median_ms": 6.642,
+      "h_l_msm_glv_median_ms": 4.924,
+      "h_l_msm_relative_to_generic": "-25.87%"
+    },
+    "generated_24_constraints": {
+      "constraints": 24,
+      "public_inputs": 8,
+      "domain_size": 32,
+      "previous_prove_full_median_ms": 27.659,
+      "prove_full_median_ms": 27.626,
+      "prove_full_relative_to_previous": "-0.12%",
+      "h_l_msm_generic_median_ms": 11.907,
+      "h_l_msm_glv_median_ms": 9.647,
+      "h_l_msm_relative_to_generic": "-18.98%",
+      "h_l_query_g1_generic_backend": "pippenger_w5",
+      "h_l_query_g1_glv_backend": "g1_glv_pippenger_w5",
+      "h_l_query_g1_size": 51,
+      "h_l_query_g1_expanded_size": 90,
+      "h_l_query_g1_glv_max_scalar_bits": 127
+    }
+  },
+  "notes": [
+    "The A/B1 fused G1 query MSM was benchmarked separately in a quick timing check and did not improve, so it remains on the existing fused pair MSM path.",
+    "The GLV-MSM helper expands each G1 base into P and phi(P) terms and feeds the shorter signed components into the existing MSM backend.",
+    "The helper uses BigInt scalar decomposition today, so further wins likely require limb-native GLV decomposition before routing more prover buckets.",
+    "The generated fixture is the preferred continuity signal; end-to-end prove_full stayed essentially flat while the H/L phase improved."
+  ]
+}

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -338,6 +338,31 @@ The `scalar_plumbing` fixture reported `g2_subgroup_scalar_mul(delta_g2, s)` at
 path in the Stage 8A notes. Verifier subgroup checks still use generic G2 scalar
 multiplication because proof inputs are untrusted.
 
+## G1 GLV-MSM Prover Snapshot (2026-05-11)
+
+The G1 GLV-MSM prover artifact is:
+
+- tracked summary:
+  `docs/src/assets/g1_glv_msm_tuning_2026_05_11.json`
+- local full artifact:
+  `benchmarks/artifacts/2026-05-11_193033/results/benchmark_results.json`
+
+This run routes only the combined H/L G1 prover MSM through explicit BN254 G1
+GLV decomposition. The A/B1 fused query MSM was checked separately and did not
+improve, so it remains on the existing fused pair MSM path.
+
+| Fixture | Generic H/L MSM | G1 GLV H/L MSM | Phase change | `prove_full` |
+| --- | ---: | ---: | ---: | ---: |
+| `sum_of_products_small` | `6.642 ms` | `4.924 ms` | `-25.87%` | `11.594 ms` |
+| `generated_24_constraints` | `11.907 ms` | `9.647 ms` | `-18.98%` | `27.626 ms` |
+
+For the generated fixture, the H/L query has `51` original bases and expands to
+`90` GLV terms with maximum component width `127` bits. Interpretation: the
+MSM phase improvement is clear, but end-to-end proving is essentially flat
+relative to the preceding same-day run (`27.659 ms -> 27.626 ms`). The next GLV
+follow-through is limb-native decomposition; the current helper still pays
+`BigInt` decomposition cost.
+
 ## Latest Snapshot (2025‑09‑29)
 
 ```@example

--- a/docs/src/curves.md
+++ b/docs/src/curves.md
@@ -28,6 +28,8 @@ Depth = 2
 - `g2_subgroup_scalar_mul` exposes BN254 G2 GLV acceleration only for points
   already known to be in the prime-order subgroup. Generic `scalar_mul` remains
   the safe scalar path for arbitrary G2 points.
+- `g1_subgroup_multi_scalar_mul` exposes BN254 G1 GLV decomposition for
+  subgroup-owned variable-base MSM workloads.
 
 ## Follow-ups
 
@@ -51,6 +53,8 @@ ProjectivePoint
 GrothCurves.doubling_step
 GrothCurves.addition_step
 GrothCurves.evaluate_line
+GrothCurves.g1_subgroup_multi_scalar_mul
+GrothCurves.g1_subgroup_multi_scalar_mul_pair
 GrothCurves.g2_subgroup_scalar_mul
 ```
 

--- a/docs/src/implementation-vs-arkworks.md
+++ b/docs/src/implementation-vs-arkworks.md
@@ -27,7 +27,7 @@ Depth = 2
 
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
-| Variable-base MSM | Straus / Pippenger variants with endomorphism support where safe. | `GrothAlgebra.multi_scalar_mul` uses a Pippenger-style backend with a small-input Straus fallback; BN254 G1 now has a measured hybrid GLV path, and G2 exposes GLV through an explicit subgroup-only helper rather than the arbitrary-point default. |
+| Variable-base MSM | Straus / Pippenger variants with endomorphism support where safe. | `GrothAlgebra.multi_scalar_mul` uses a Pippenger-style backend with a small-input Straus fallback; BN254 G1 has measured single-scalar GLV and an explicit subgroup-owned GLV-MSM path for the prover H/L query, while G2 exposes scalar GLV through an explicit subgroup-only helper rather than the arbitrary-point default. |
 | Fixed-base tables | `FixedBaseMSM` window tables. | `FixedBaseTable` plus `build_fixed_table`, `mul_fixed`, and `batch_mul` mirror the workflow; setup uses measured BN254 scalar/GLV dispatch for G1 query generation and a fixed-window batch path for the G2 query. |
 
 **Next steps:** keep MSM work tied to the real `prove_full` fixtures and avoid
@@ -46,7 +46,7 @@ treating synthetic MSM sweeps as the sole tuning signal.
 | Topic | Arkworks | Groth.jl |
 | --- | --- | --- |
 | R1CS → QAP | Domain fully populated, IFFT then FFT on the coset. | Same structure; constraints, public-input selector slots, and zero padding are all explicit before IFFT. |
-| Prover/setup | Coset FFT path, dense available for debugging. | `prove_full` uses coset-only H computation and combines H/L into one G1 MSM for `C`; `setup_full` uses measured query-generation dispatch; subgroup-owned fixed G2 elements use explicit GLV; dense/coset parity is kept in explicit debug/test helpers. |
+| Prover/setup | Coset FFT path, dense available for debugging. | `prove_full` uses coset-only H computation and combines H/L into one subgroup-owned G1 GLV-MSM for `C`; `setup_full` uses measured query-generation dispatch; subgroup-owned fixed G2 elements use explicit GLV; dense/coset parity is kept in explicit debug/test helpers. |
 | Prepared verifier | `PreparedVerifyingKey` batches pairings. | `prepare_verifying_key`, `prepare_inputs`, and `verify_with_prepared` mirror the API. |
 | Aggregation | Optional `groth16::aggregate_proofs`. | Not yet ported; tracked on the roadmap. |
 

--- a/docs/src/proofs.md
+++ b/docs/src/proofs.md
@@ -26,7 +26,8 @@ Depth = 2
 - `prove_full` uses the coset-only H quotient path; dense vs coset parity is
   still asserted in tests and available through the checked helper.
 - The prover combines H and private-variable L into one G1 MSM for the `C`
-  proof element, since the algebra only needs their sum.
+  proof element, since the algebra only needs their sum. That combined H/L MSM
+  now uses explicit BN254 G1 GLV decomposition on subgroup-owned CRS points.
 - `setup_full` uses the measured BN254 G1 scalar/GLV path for G1 query
   generation and a fixed-window batch path for the G2 query.
 - Fixed G2 key elements and the prover `delta_g2` randomizer term use the


### PR DESCRIPTION
## Summary
- add explicit BN254 G1 subgroup GLV-MSM helpers
- route only the combined H/L prover MSM through G1 GLV-MSM
- leave the A/B1 fused pair MSM on the existing path because the quick timing check did not improve
- update benchmark metadata, plots, docs, and tracked benchmark summary

## Validation
- `Pkg.test("GrothCurves")`
- `Pkg.test("GrothProofs")`
- `include("scripts/test_all.jl")`
- docs build: `include("make.jl")` from `docs/`

## Benchmarks
- focused run: `benchmarks/artifacts/2026-05-11_193033/results/benchmark_results.json`
- generated fixture H/L generic: `11.907 ms`
- generated fixture H/L G1 GLV: `9.647 ms` (`-18.98%`)
- generated fixture `prove_full`: `27.626 ms`, essentially flat versus preceding same-day run `27.659 ms`
- small fixture H/L generic: `6.642 ms`; G1 GLV: `4.924 ms` (`-25.87%`)

## Notes
The helper currently uses BigInt scalar decomposition, so the next obvious follow-through is limb-native GLV decomposition before routing more prover buckets.