### PR TITLE
curves: add limb-native GLV decomposition

### DIFF
--- a/GrothCurves/src/BN254Curve.jl
+++ b/GrothCurves/src/BN254Curve.jl
@@ -29,6 +29,23 @@ const BN254_G2_GLV_DECOMP_MATRIX = (
     parse(BigInt, "9931322734385697763"),
     -parse(BigInt, "147946756881789319000765030803803410728"),
 )
+const _GLVUInt256 = GrothAlgebra.UInt256
+const _GLVUInt512 = GrothAlgebra.UInt512
+const _GLVInt256 = GrothAlgebra.Int256
+const BN254_ORDER_R_U256 = parse(_GLVUInt256, "21888242871839275222246405745257275088548364400416034343698204186575808495617")
+const BN254_ORDER_R_U512 = _GLVUInt512(BN254_ORDER_R_U256)
+const BN254_G1_GLV_DECOMP_MATRIX_I256 = (
+    -parse(_GLVInt256, "147946756881789319000765030803803410728"),
+    parse(_GLVInt256, "9931322734385697763"),
+    -parse(_GLVInt256, "9931322734385697763"),
+    -parse(_GLVInt256, "147946756881789319010696353538189108491"),
+)
+const BN254_G2_GLV_DECOMP_MATRIX_I256 = (
+    -parse(_GLVInt256, "147946756881789319010696353538189108491"),
+    -parse(_GLVInt256, "9931322734385697763"),
+    parse(_GLVInt256, "9931322734385697763"),
+    -parse(_GLVInt256, "147946756881789319000765030803803410728"),
+)
 # Keep small and medium scalars on the existing w-NAF path; the Stage 7A
 # scalar sweep shows GLV only starts to pull ahead on larger bitlengths.
 const BN254_G1_GLV_THRESHOLD_BITS = 192
@@ -104,10 +121,39 @@ G2Point(X::Fp2Element, Y::Fp2Element) = G2Point(X, Y, G2_AFFINE_Z)
 
 @inline _square(x) = x * x
 @inline _square(x::Fp2Element) = square(x)
-@inline _glv_bit_length(k::BigInt) = iszero(k) ? 0 : ndigits(k, base=2)
+@inline _glv_bit_length(k::Integer) = iszero(k) ? 0 : ndigits(k, base=2)
 
-@inline function _glv_decomposition_bits(k1::BigInt, k2::BigInt)
+@inline function _glv_decomposition_bits(k1::Integer, k2::Integer)
     return max(_glv_bit_length(k1), _glv_bit_length(k2))
+end
+
+@inline function _u256_from_limbs(limbs::NTuple{4,UInt64})
+    return _GLVUInt256(limbs[1]) |
+           (_GLVUInt256(limbs[2]) << 64) |
+           (_GLVUInt256(limbs[3]) << 128) |
+           (_GLVUInt256(limbs[4]) << 192)
+end
+
+@inline _bn254fr_scalar_u256(k::GrothAlgebra.BN254Fr) =
+    _u256_from_limbs(GrothAlgebra.canonical_limbs(k))
+
+@inline function _round_mul_div_order(k::_GLVUInt256, coeff_abs::_GLVUInt256)
+    numerator = _GLVUInt512(k) * _GLVUInt512(coeff_abs)
+    quotient, remainder = divrem(numerator, BN254_ORDER_R_U512)
+    if remainder + remainder > BN254_ORDER_R_U512
+        quotient += _GLVUInt512(1)
+    end
+    return _GLVInt256(quotient)
+end
+
+@inline function _round_signed_mul_div_order(k::_GLVUInt256, coeff::_GLVInt256)
+    if coeff < _GLVInt256(0)
+        numerator = _GLVUInt512(k) * _GLVUInt512(_GLVUInt256(-coeff))
+        quotient = numerator ÷ BN254_ORDER_R_U512
+        return -_GLVInt256(quotient)
+    end
+
+    return _round_mul_div_order(k, _GLVUInt256(coeff))
 end
 
 function _glv_scalar_decomposition(k::Integer, coeffs::NTuple{4,BigInt})
@@ -134,15 +180,36 @@ function _glv_scalar_decomposition(k::Integer, coeffs::NTuple{4,BigInt})
     return ((k1 >= 0, abs(k1)), (k2 >= 0, abs(k2)))
 end
 
+function _glv_scalar_decomposition(k::_GLVUInt256, coeffs::NTuple{4,_GLVInt256})
+    iszero(k) && return ((true, _GLVInt256(0)), (true, _GLVInt256(0)))
+
+    n11, n12, n21, n22 = coeffs
+    beta_1 = _round_signed_mul_div_order(k, n22)
+    beta_2 = _round_signed_mul_div_order(k, -n12)
+
+    b1 = beta_1 * n11 + beta_2 * n21
+    b2 = beta_1 * n12 + beta_2 * n22
+    k1 = _GLVInt256(k) - b1
+    k2 = -b2
+
+    return ((k1 >= _GLVInt256(0), abs(k1)), (k2 >= _GLVInt256(0), abs(k2)))
+end
+
 """
     glv_scalar_decomposition(::Type{G1Point}, k::Integer)
     glv_scalar_decomposition(::Type{G2Point}, k::Integer)
+    glv_scalar_decomposition(::Type{G1Point}, k::GrothAlgebra.BN254Fr)
+    glv_scalar_decomposition(::Type{G2Point}, k::GrothAlgebra.BN254Fr)
 
 Decompose a scalar into the signed two-term representation used by the BN254
 GLV scalar-multiplication path for the selected group.
 """
 glv_scalar_decomposition(::Type{G1Point}, k::Integer) = _glv_scalar_decomposition(k, BN254_G1_GLV_DECOMP_MATRIX)
 glv_scalar_decomposition(::Type{G2Point}, k::Integer) = _glv_scalar_decomposition(k, BN254_G2_GLV_DECOMP_MATRIX)
+glv_scalar_decomposition(::Type{G1Point}, k::GrothAlgebra.BN254Fr) =
+    _glv_scalar_decomposition(_bn254fr_scalar_u256(k), BN254_G1_GLV_DECOMP_MATRIX_I256)
+glv_scalar_decomposition(::Type{G2Point}, k::GrothAlgebra.BN254Fr) =
+    _glv_scalar_decomposition(_bn254fr_scalar_u256(k), BN254_G2_GLV_DECOMP_MATRIX_I256)
 
 glv_lambda(::Type{G1Point}) = BN254_G1_GLV_LAMBDA
 glv_lambda(::Type{G2Point}) = BN254_G2_GLV_LAMBDA
@@ -231,7 +298,7 @@ function glv_scalar_mul(p::P, k::GrothAlgebra.BN254Fr) where {P<:ProjectivePoint
         return p
     end
 
-    coeffs = glv_scalar_decomposition(P, _bn254fr_scalar_bigint(k))
+    coeffs = glv_scalar_decomposition(P, k)
     return _glv_joint_scalar_mul(p, coeffs, glv_endomorphism(p))
 end
 
@@ -267,6 +334,27 @@ function _append_g1_glv_terms!(out_points::Vector{G1Point}, out_scalars::Vector{
     return nothing
 end
 
+function _append_g1_glv_terms!(
+    out_points::Vector{G1Point},
+    out_scalars::Vector{_GLVInt256},
+    p::G1Point,
+    scalar::GrothAlgebra.BN254Fr,
+)
+    ((sgn_k1, k1), (sgn_k2, k2)) = glv_scalar_decomposition(G1Point, scalar)
+
+    if !iszero(k1)
+        push!(out_points, p)
+        push!(out_scalars, sgn_k1 ? k1 : -k1)
+    end
+
+    if !iszero(k2)
+        push!(out_points, glv_endomorphism(p))
+        push!(out_scalars, sgn_k2 ? k2 : -k2)
+    end
+
+    return nothing
+end
+
 """
     g1_subgroup_multi_scalar_mul(points::Vector{G1Point}, scalars::Vector)
 
@@ -286,6 +374,27 @@ function g1_subgroup_multi_scalar_mul(points::Vector{G1Point}, scalars::Vector{S
 
     glv_points = G1Point[]
     glv_scalars = BigInt[]
+    sizehint!(glv_points, 2 * length(points))
+    sizehint!(glv_scalars, 2 * length(scalars))
+
+    @inbounds for i in eachindex(points, scalars)
+        _append_g1_glv_terms!(glv_points, glv_scalars, points[i], scalars[i])
+    end
+
+    isempty(glv_points) && return zero(points[1])
+    return GrothAlgebra.multi_scalar_mul(glv_points, glv_scalars)
+end
+
+function g1_subgroup_multi_scalar_mul(points::Vector{G1Point}, scalars::Vector{GrothAlgebra.BN254Fr})
+    length(points) == length(scalars) || throw(ArgumentError("Points and scalars must have the same length"))
+    isempty(points) && throw(ArgumentError("Cannot compute multi-scalar multiplication of empty vectors"))
+
+    if length(points) == 1
+        return GrothAlgebra.scalar_mul(points[1], scalars[1])
+    end
+
+    glv_points = G1Point[]
+    glv_scalars = _GLVInt256[]
     sizehint!(glv_points, 2 * length(points))
     sizehint!(glv_scalars, 2 * length(scalars))
 

--- a/GrothCurves/test/test_bn254_curve.jl
+++ b/GrothCurves/test/test_bn254_curve.jl
@@ -35,8 +35,9 @@ function scalar_mul_reference(P, k::Integer)
     return result
 end
 
-glv_signed_value(component::Tuple{Bool,BigInt}) = component[1] ? component[2] : -component[2]
-glv_component_bits(component::Tuple{Bool,BigInt}) = iszero(component[2]) ? 0 : ndigits(component[2], base=2)
+glv_signed_value(component::Tuple{Bool,<:Integer}) = component[1] ? component[2] : -component[2]
+glv_component_bits(component::Tuple{Bool,<:Integer}) = iszero(component[2]) ? 0 : ndigits(component[2], base=2)
+glv_component_bigint(component::Tuple{Bool,<:Integer}) = (component[1], BigInt(component[2]))
 
 @testset "BN254 Curve Operations" begin
     
@@ -437,6 +438,31 @@ glv_component_bits(component::Tuple{Bool,BigInt}) = iszero(component[2]) ? 0 : n
 
             for scalar in fr_scalars
                 scalar_big = convert(BigInt, scalar)
+                @test map(glv_component_bigint, GrothCurves.glv_scalar_decomposition(G1Point, scalar)) ==
+                      GrothCurves.glv_scalar_decomposition(G1Point, scalar_big)
+                @test map(glv_component_bigint, GrothCurves.glv_scalar_decomposition(G2Point, scalar)) ==
+                      GrothCurves.glv_scalar_decomposition(G2Point, scalar_big)
+
+                g1_k1, g1_k2 = GrothCurves.glv_scalar_decomposition(G1Point, scalar)
+                g2_k1, g2_k2 = GrothCurves.glv_scalar_decomposition(G2Point, scalar)
+                @test g1_k1[2] isa GrothAlgebra.Int256
+                @test g1_k2[2] isa GrothAlgebra.Int256
+                @test g2_k1[2] isa GrothAlgebra.Int256
+                @test g2_k2[2] isa GrothAlgebra.Int256
+
+                g1_lhs = mod(
+                    BigInt(glv_signed_value(g1_k1)) +
+                    BigInt(glv_signed_value(g1_k2)) * GrothCurves.glv_lambda(G1Point),
+                    GrothCurves.BN254_ORDER_R,
+                )
+                g2_lhs = mod(
+                    BigInt(glv_signed_value(g2_k1)) +
+                    BigInt(glv_signed_value(g2_k2)) * GrothCurves.glv_lambda(G2Point),
+                    GrothCurves.BN254_ORDER_R,
+                )
+                @test g1_lhs == scalar_big
+                @test g2_lhs == scalar_big
+
                 @test scalar_mul(g1, scalar) == scalar_mul_reference(g1, scalar_big)
                 @test scalar_mul(g2, scalar) == scalar_mul_reference(g2, scalar_big)
                 @test g2_subgroup_scalar_mul(g2, scalar) == scalar_mul_reference(g2, scalar_big)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ The project has moved well beyond a minimal Groth16 demo.
   from `11.907 ms` to `9.647 ms`; end-to-end `prove_full` stayed essentially
   flat at `27.626 ms` in
   [docs/src/assets/g1_glv_msm_tuning_2026_05_11.json](./docs/src/assets/g1_glv_msm_tuning_2026_05_11.json).
+- The BN254Fr GLV decomposition path now stays in fixed-width limb-native
+  arithmetic instead of converting through `BigInt`. The generated fixture's
+  H/L GLV-MSM measured `9.538 ms`, and scalar-plumbing checks show low
+  single-digit percentage wins across the relevant BN254Fr paths in
+  [docs/src/assets/limb_native_glv_decomposition_2026_05_11.json](./docs/src/assets/limb_native_glv_decomposition_2026_05_11.json).
 - The current larger deterministic `setup_full` fixture is `116.918 ms` in
   [docs/src/assets/setup_full_tuning_2026_05_11.json](./docs/src/assets/setup_full_tuning_2026_05_11.json),
   down from the `142.715 ms` pre-change baseline on the same fixture.
@@ -166,17 +171,19 @@ These are primitive-level measurements, not end-to-end Groth16 prover
 comparisons.
 
 Latest tracked `prove_full` prover fixture summary
-(`2026-05-11_193033`, G1 GLV-MSM focused profile):
+(`2026-05-11_195230`, limb-native GLV focused profile):
 
 | Fixture | Domain | `prove_full` | Key prover phases |
 | --- | ---: | ---: | --- |
-| `sum_of_products_small` | `16` | `11.594 ms` | H+L MSM `4.924 ms`, final C `2.444 ms` |
-| `generated_24_constraints` | `32` | `27.626 ms` | H+L MSM `9.647 ms`, final C `2.488 ms` |
+| `sum_of_products_small` | `16` | `10.024 ms` | H+L MSM `4.717 ms`, final C `2.270 ms` |
+| `generated_24_constraints` | `32` | `26.606 ms` | H+L MSM `9.538 ms`, final C `2.341 ms` |
 
 The current production H/L MSM uses explicit BN254 G1 GLV decomposition on
-subgroup-owned CRS points. In the generated fixture it was `18.98%` faster than
-the generic H/L MSM measured in the same run; the end-to-end prover movement is
-small enough that we treat it as flat rather than a headline speedup.
+subgroup-owned CRS points. In the generated fixture it was `23.48%` faster than
+the generic H/L MSM measured in the same run. Limb-native decomposition removes
+the previous `BN254Fr` to `BigInt` round trip for this path; the end-to-end
+movement is still small enough to treat as a plumbing win rather than a headline
+prover speedup.
 
 Latest tracked `setup_full` fixture summary
 (`2026-05-11_175228`, setup profile):

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -421,9 +421,32 @@ on the existing fused pair MSM.
 
 The generated fixture H/L query has `51` original bases and expands to `90` GLV
 terms with `127`-bit maximum components. Treat this as a clear H/L phase win
-with essentially flat end-to-end prover movement; the helper still uses
-`BigInt` decomposition, so limb-native GLV decomposition is the natural next
-follow-through.
+with essentially flat end-to-end prover movement. At this point the helper
+still used `BigInt` decomposition, which motivated the limb-native follow-up
+below.
+
+## Limb-Native GLV Decomposition Snapshot (2026-05-11)
+
+- Focused run:
+  `artifacts/2026-05-11_195230/results/benchmark_results.json`
+- Tracked summary:
+  `../docs/src/assets/limb_native_glv_decomposition_2026_05_11.json`
+
+This run keeps the same GLV decomposition semantics but routes `BN254Fr`
+decomposition through fixed-width limb-native arithmetic instead of converting
+through `BigInt`. The generated fixture scalar-plumbing checks report:
+
+| Workload | BigInt | BN254Fr limb-native | Change |
+| --- | ---: | ---: | ---: |
+| `g1_scalar_delta` | `0.855 ms` | `0.804 ms` | `-5.98%` |
+| `A_query` MSM | `3.508 ms` | `3.357 ms` | `-4.30%` |
+| `H` MSM | `9.893 ms` | `9.257 ms` | `-6.43%` |
+| `L` MSM | `4.289 ms` | `4.137 ms` | `-3.54%` |
+
+The refreshed generated fixture reports generic H/L MSM at `12.464 ms`,
+limb-native GLV H/L MSM at `9.538 ms`, and end-to-end `prove_full` at
+`26.606 ms`. The practical interpretation is a modest scalar-plumbing cleanup,
+not a new MSM algorithm.
 
 Generate a full report (run -> plot -> compare) for latest run:
 

--- a/benchmarks/prove_full_common.jl
+++ b/benchmarks/prove_full_common.jl
@@ -222,7 +222,7 @@ function g1_glv_msm_selection_metadata(points::AbstractVector{G1Point}, scalars:
     max_bits = 0
     nonzero_scalars = 0
     @inbounds for scalar in scalars
-        ((_, k1), (_, k2)) = GrothCurves.glv_scalar_decomposition(G1Point, convert(BigInt, scalar))
+        ((_, k1), (_, k2)) = GrothCurves.glv_scalar_decomposition(G1Point, scalar)
         if !iszero(k1)
             expanded_size += 1
             max_bits = max(max_bits, GrothAlgebra._bit_length(k1))

--- a/docs/PACKAGE_REFERENCE.md
+++ b/docs/PACKAGE_REFERENCE.md
@@ -59,6 +59,10 @@ annotated rather than discarded), and follow-ups.
   `g2_subgroup_scalar_mul` for points already known to be in the BN254
   prime-order subgroup, while generic G2 `scalar_mul` remains the safe path for
   arbitrary on-curve points.
+- (2026-05-11) `BN254Fr` GLV decomposition now stays in fixed-width
+  `UInt256`/`UInt512`/`Int256` arithmetic and matches the previous BigInt
+  decomposition exactly. The generic `Integer` decomposition remains
+  BigInt-based for external callers.
 - (2026-04-01) Stage 4 of the Montgomery roadmap replaced `SVector`-backed
   `Fp2`/`Fp6`/`Fp12` storage with concrete field members and specialized
   nonresidue helpers for `xi = 9 + u` and `v = (0, 1, 0)`. The first Stage 4
@@ -99,6 +103,10 @@ annotated rather than discarded), and follow-ups.
   GLV-MSM helper. The generated fixture's H/L phase measured `9.647 ms` versus
   `11.907 ms` for the generic MSM in the same run; end-to-end `prove_full`
   remained essentially flat at `27.626 ms`.
+- (2026-05-11) Limb-native `BN254Fr` GLV decomposition removes the BigInt
+  round trip from that H/L GLV-MSM expansion. The refreshed generated fixture
+  reports H/L GLV-MSM at `9.538 ms` versus generic H/L MSM at `12.464 ms`, with
+  `prove_full` at `26.606 ms`.
 - (2026-05-11) `setup_full` routes G1 query generation through the BN254 scalar
   dispatcher, whose GLV path beats fixed-base w-NAF for the measured setup
   scalars; the G2 query uses a fixed-window batch path.
@@ -148,6 +156,12 @@ annotated rather than discarded), and follow-ups.
   with tracked summary `docs/src/assets/g1_glv_msm_tuning_2026_05_11.json`.
   The `generated_24_constraints` fixture reports `prove_full` at `27.626 ms`,
   generic H/L MSM at `11.907 ms`, and G1 GLV H/L MSM at `9.647 ms`.
+- Latest limb-native GLV decomposition artifact:
+  `benchmarks/artifacts/2026-05-11_195230`, with tracked summary
+  `docs/src/assets/limb_native_glv_decomposition_2026_05_11.json`. The
+  `generated_24_constraints` fixture reports `prove_full` at `26.606 ms`,
+  generic H/L MSM at `12.464 ms`, and limb-native G1 GLV H/L MSM at
+  `9.538 ms`.
 - Latest setup-focused artifact: `benchmarks/artifacts/2026-05-11_175228`,
   with tracked summary `docs/src/assets/setup_full_tuning_2026_05_11.json`.
   The `generated_24_constraints` fixture reports `setup_full` at `116.918 ms`,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -73,6 +73,11 @@ an arkworks-aligned, production-friendly Groth16 stack.
   generated fixture measured `9.647 ms` for the H/L phase versus `11.907 ms`
   for the generic MSM in the same run, with end-to-end proving essentially
   flat at `27.626 ms`.
+- The BN254Fr GLV decomposition path now stays in fixed-width limb-native
+  arithmetic and matches the previous BigInt decomposition exactly. The
+  refreshed generated fixture measured `9.538 ms` for the H/L GLV-MSM phase
+  versus `12.464 ms` for generic H/L MSM in the same run, with `prove_full` at
+  `26.606 ms`.
 - `setup_full` query generation now uses BN254 G1 scalar/GLV dispatch for G1
   queries and a fixed-window G2 batch path; the generated fixture is now
   `116.918 ms`.

--- a/docs/src/assets/limb_native_glv_decomposition_2026_05_11.json
+++ b/docs/src/assets/limb_native_glv_decomposition_2026_05_11.json
@@ -1,0 +1,88 @@
+{
+  "summary": "Limb-native BN254Fr GLV decomposition: BN254Fr scalar decomposition now stays in fixed-width UInt256/UInt512/Int256 arithmetic instead of converting through BigInt. The change preserves the previous BigInt decomposition results while reducing scalar-plumbing overhead in the prover-shaped fixture.",
+  "date": "2026-05-11",
+  "valid_artifact": "benchmarks/artifacts/2026-05-11_195230/results/benchmark_results.json",
+  "benchmark_profile": "custom",
+  "groups": [
+    "scalar_plumbing",
+    "glv_scalar_tuning",
+    "prove_full"
+  ],
+  "environment": {
+    "cpu_name": "znver5",
+    "julia_version": "1.12.6",
+    "threadpools": {
+      "default": 24,
+      "interactive": 1
+    },
+    "machine": "x86_64-linux-gnu"
+  },
+  "scalar_plumbing_generated_24_constraints": {
+    "g1_scalar_delta": {
+      "bigint_median_ms": 0.855,
+      "bn254fr_limb_native_median_ms": 0.804,
+      "relative_to_bigint": "-5.98%"
+    },
+    "g2_subgroup_delta": {
+      "bigint_median_ms": 1.734,
+      "bn254fr_limb_native_median_ms": 1.689,
+      "relative_to_bigint": "-2.60%"
+    },
+    "a_query_msm": {
+      "bigint_median_ms": 3.508,
+      "bn254fr_limb_native_median_ms": 3.357,
+      "relative_to_bigint": "-4.30%"
+    },
+    "b2_query_msm": {
+      "bigint_median_ms": 4.826,
+      "bn254fr_limb_native_median_ms": 4.704,
+      "relative_to_bigint": "-2.53%"
+    },
+    "h_msm": {
+      "bigint_median_ms": 9.893,
+      "bn254fr_limb_native_median_ms": 9.257,
+      "relative_to_bigint": "-6.43%"
+    },
+    "l_msm": {
+      "bigint_median_ms": 4.289,
+      "bn254fr_limb_native_median_ms": 4.137,
+      "relative_to_bigint": "-3.54%"
+    }
+  },
+  "prove_full": {
+    "sum_of_products_small": {
+      "domain_size": 16,
+      "prove_full_median_ms": 10.024,
+      "h_l_msm_generic_median_ms": 5.871,
+      "h_l_msm_glv_limb_native_median_ms": 4.717,
+      "h_l_msm_relative_to_generic": "-19.65%"
+    },
+    "generated_24_constraints": {
+      "domain_size": 32,
+      "prove_full_median_ms": 26.606,
+      "h_l_msm_generic_median_ms": 12.464,
+      "h_l_msm_glv_limb_native_median_ms": 9.538,
+      "h_l_msm_relative_to_generic": "-23.48%",
+      "previous_glv_msm_median_ms": 9.647,
+      "relative_to_previous_glv_msm": "-1.13%",
+      "previous_prove_full_median_ms": 27.626,
+      "relative_to_previous_prove_full": "-3.69%",
+      "h_l_query_g1_glv_backend": "g1_glv_pippenger_w5",
+      "h_l_query_g1_size": 51,
+      "h_l_query_g1_expanded_size": 90,
+      "h_l_query_g1_nonzero_scalars": 47,
+      "h_l_query_g1_glv_max_scalar_bits": 127
+    }
+  },
+  "validation": [
+    "BN254Fr GLV decomposition matches the previous BigInt decomposition on deterministic G1/G2 scalar fixtures.",
+    "GLV identities k == k1 + lambda*k2 mod r are checked for BN254Fr G1 and G2 decompositions.",
+    "BN254Fr scalar multiplication, G2 subgroup scalar multiplication, and G1 subgroup GLV-MSM results match reference/generic paths.",
+    "Pkg.test(\"GrothCurves\"), Pkg.test(\"GrothProofs\"), and include(\"scripts/test_all.jl\") passed."
+  ],
+  "notes": [
+    "This is a scalar-plumbing optimization, not a new MSM algorithm.",
+    "The generic Integer GLV decomposition remains BigInt-based for external integer callers.",
+    "The clean benchmark artifact is 2026-05-11_195230; an earlier same-turn run was discarded because the Julia session still had the pre-fix helper loaded."
+  ]
+}

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -359,9 +359,45 @@ improve, so it remains on the existing fused pair MSM path.
 For the generated fixture, the H/L query has `51` original bases and expands to
 `90` GLV terms with maximum component width `127` bits. Interpretation: the
 MSM phase improvement is clear, but end-to-end proving is essentially flat
-relative to the preceding same-day run (`27.659 ms -> 27.626 ms`). The next GLV
-follow-through is limb-native decomposition; the current helper still pays
-`BigInt` decomposition cost.
+relative to the preceding same-day run (`27.659 ms -> 27.626 ms`).
+
+## Limb-Native GLV Decomposition Snapshot (2026-05-11)
+
+- Focused run:
+  `artifacts/2026-05-11_195230/results/benchmark_results.json`
+- Tracked summary:
+  `docs/src/assets/limb_native_glv_decomposition_2026_05_11.json`
+
+This pass keeps the same GLV lattice decomposition semantics, but routes
+`BN254Fr` scalars through fixed-width `UInt256`/`UInt512`/`Int256` arithmetic
+instead of decoding to `BigInt`. The generic `Integer` GLV path remains
+`BigInt`-based for external callers. Tests compare the new `BN254Fr`
+decomposition against the previous BigInt decomposition and re-check
+`k == k1 + lambda*k2 mod r` for G1 and G2.
+
+Scalar-plumbing medians on the generated fixture:
+
+| Workload | BigInt | BN254Fr limb-native | Change |
+| --- | ---: | ---: | ---: |
+| `g1_scalar_delta` | `0.855 ms` | `0.804 ms` | `-5.98%` |
+| `g2_subgroup_delta` | `1.734 ms` | `1.689 ms` | `-2.60%` |
+| `A_query` MSM | `3.508 ms` | `3.357 ms` | `-4.30%` |
+| `B2_query` MSM | `4.826 ms` | `4.704 ms` | `-2.53%` |
+| `H` MSM | `9.893 ms` | `9.257 ms` | `-6.43%` |
+| `L` MSM | `4.289 ms` | `4.137 ms` | `-3.54%` |
+
+Prover fixture summary:
+
+| Fixture | Generic H/L MSM | Limb-native GLV H/L MSM | Phase change | `prove_full` |
+| --- | ---: | ---: | ---: | ---: |
+| `sum_of_products_small` | `5.871 ms` | `4.717 ms` | `-19.65%` | `10.024 ms` |
+| `generated_24_constraints` | `12.464 ms` | `9.538 ms` | `-23.48%` | `26.606 ms` |
+
+For the generated fixture, the H/L GLV phase moved from `9.647 ms` in the prior
+G1 GLV-MSM artifact to `9.538 ms` here (`-1.13%`). End-to-end `prove_full`
+moved from `27.626 ms` to `26.606 ms` (`-3.69%`), but the safer reading is that
+limb-native decomposition trims plumbing overhead without changing the broader
+prover performance picture.
 
 ## Latest Snapshot (2025‑09‑29)
 


### PR DESCRIPTION
## Summary
- add a fixed-width BN254Fr GLV decomposition path using UInt256/UInt512/Int256 arithmetic
- route BN254Fr GLV scalar multiplication and G1 subgroup GLV-MSM expansion through the limb-native path
- update tests, benchmark metadata, and benchmark docs with the 2026-05-11_195230 artifact

## Validation
- Pkg.test("GrothCurves")
- Pkg.test("GrothProofs")
- include("scripts/test_all.jl")
- docs/make.jl
- benchmarks/run.jl --groups=scalar_plumbing,glv_scalar_tuning,prove_full
- benchmarks/plot.jl 2026-05-11_195230