### PR TITLE
pairing: specialize final exponentiation

### DIFF
--- a/GrothCurves/src/BN254FinalExp.jl
+++ b/GrothCurves/src/BN254FinalExp.jl
@@ -224,6 +224,29 @@ function exp_by_u(a::Fp12Element)
 end
 
 """
+    cyclotomic_exp_by_u(a::Fp12Element)
+
+Compute `a^u` for an element already known to be in the cyclotomic subgroup.
+The final exponentiation hard part only calls this after the easy part has
+established that condition.
+"""
+function cyclotomic_exp_by_u(a::Fp12Element)
+    result = one(Fp12Element)
+    base = a
+    u = UInt64(4965661367192848881)
+
+    while u != 0
+        if (u & UInt64(1)) == UInt64(1)
+            result = result * base
+        end
+        base = cyclotomic_square(base)
+        u >>= 1
+    end
+
+    return result
+end
+
+"""
     final_exponentiation_hard(m::Fp12Element)
 
 Compute the hard part of the final exponentiation using the standard BN254 formula.
@@ -234,9 +257,9 @@ involving u-powers and Frobenius maps.
 """
 function final_exponentiation_hard(m::Fp12Element)
     # Compute u-powers using cyclotomic exponentiation.
-    mx = exp_by_u(m)
-    mx2 = exp_by_u(mx)
-    mx3 = exp_by_u(mx2)
+    mx = cyclotomic_exp_by_u(m)
+    mx2 = cyclotomic_exp_by_u(mx)
+    mx3 = cyclotomic_exp_by_u(mx2)
 
     # Compute Frobenius images.
     mp = frobenius_p1(m)
@@ -256,27 +279,29 @@ function final_exponentiation_hard(m::Fp12Element)
     y5 = cyclotomic_inverse(mx2)
     y6 = cyclotomic_inverse(mx3 * mx3p)
 
-    y1_2 = y1 * y1
-    y2_2 = y2 * y2
-    y2_6 = (y2_2 * y2_2) * y2_2
-    y3_3 = (y3 * y3) * y3
-    y3_6 = y3_3 * y3_3
-    y3_12 = y3_6 * y3_6
-    y4_2 = y4 * y4
-    y4_4 = y4_2 * y4_2
-    y4_8 = y4_4 * y4_4
-    y4_16 = y4_8 * y4_8
+    y1_2 = cyclotomic_square(y1)
+    y2_2 = cyclotomic_square(y2)
+    y2_4 = cyclotomic_square(y2_2)
+    y2_6 = y2_4 * y2_2
+    y3_2 = cyclotomic_square(y3)
+    y3_3 = y3_2 * y3
+    y3_6 = cyclotomic_square(y3_3)
+    y3_12 = cyclotomic_square(y3_6)
+    y4_2 = cyclotomic_square(y4)
+    y4_4 = cyclotomic_square(y4_2)
+    y4_8 = cyclotomic_square(y4_4)
+    y4_16 = cyclotomic_square(y4_8)
     y4_18 = y4_16 * y4_2
-    y5_2 = y5 * y5
-    y5_4 = y5_2 * y5_2
-    y5_8 = y5_4 * y5_4
-    y5_16 = y5_8 * y5_8
+    y5_2 = cyclotomic_square(y5)
+    y5_4 = cyclotomic_square(y5_2)
+    y5_8 = cyclotomic_square(y5_4)
+    y5_16 = cyclotomic_square(y5_8)
     y5_30 = y5_16 * y5_8 * y5_4 * y5_2
-    y6_2 = y6 * y6
-    y6_4 = y6_2 * y6_2
-    y6_8 = y6_4 * y6_4
-    y6_16 = y6_8 * y6_8
-    y6_32 = y6_16 * y6_16
+    y6_2 = cyclotomic_square(y6)
+    y6_4 = cyclotomic_square(y6_2)
+    y6_8 = cyclotomic_square(y6_4)
+    y6_16 = cyclotomic_square(y6_8)
+    y6_32 = cyclotomic_square(y6_16)
     y6_36 = y6_32 * y6_4
 
     result = y0
@@ -320,7 +345,7 @@ end
 # Export functions
 export frobenius_map, frobenius_p1, frobenius_p2, frobenius_p3
 export final_exponentiation_easy, final_exponentiation_hard
-export final_exponentiation, exp_by_u
+export final_exponentiation, exp_by_u, cyclotomic_exp_by_u
 
 """
     final_exponentiation(::BN254Engine, f::Fp12Element)

--- a/GrothCurves/src/BN254Fp12_2over6.jl
+++ b/GrothCurves/src/BN254Fp12_2over6.jl
@@ -107,6 +107,9 @@ Return the inverse of a cyclotomic-subgroup element via conjugation.
 """
 cyclotomic_inverse(a::Fp12Element) = conjugate(a)
 
+@inline _fp2_double(a::Fp2Element) = a + a
+@inline _fp2_triple(a::Fp2Element) = _fp2_double(a) + a
+
 """
     cyclotomic_square(a::Fp12Element)
 
@@ -133,13 +136,13 @@ function cyclotomic_square(a::Fp12Element)
     t4 = (r4 + r5) * (mul_fp2_by_nonresidue(r5) + r4) - tmp - mul_fp2_by_nonresidue(tmp)
     t5 = tmp + tmp
 
-    z0 = (t0 - r0) * 2 + t0
-    z1 = (t1 + r1) * 2 + t1
+    z0 = _fp2_triple(t0) - _fp2_double(r0)
+    z1 = _fp2_triple(t1) + _fp2_double(r1)
     z2_tmp = mul_fp2_by_nonresidue(t5)
-    z2 = (r2 + z2_tmp) * 2 + z2_tmp
-    z3 = (t4 - r3) * 2 + t4
-    z4 = (t2 - r4) * 2 + t2
-    z5 = (r5 + t3) * 2 + t3
+    z2 = _fp2_double(r2) + _fp2_triple(z2_tmp)
+    z3 = _fp2_triple(t4) - _fp2_double(r3)
+    z4 = _fp2_triple(t2) - _fp2_double(r4)
+    z5 = _fp2_double(r5) + _fp2_triple(t3)
 
     return Fp12Element(Fp6Element(z0, z4, z3), Fp6Element(z2, z1, z5))
 end

--- a/GrothCurves/src/GrothCurves.jl
+++ b/GrothCurves/src/GrothCurves.jl
@@ -44,7 +44,7 @@ export x_coord, y_coord, z_coord
 export LineCoeffs, doubling_step, addition_step, evaluate_line, miller_loop, frobenius_g2
 export frobenius_map, frobenius_p1, frobenius_p2, frobenius_p3
 export final_exponentiation_easy, final_exponentiation_hard
-export final_exponentiation, exp_by_u
+export final_exponentiation, exp_by_u, cyclotomic_exp_by_u
 export optimal_ate_pairing, pairing, pairing_batch
 
 end

--- a/GrothCurves/test/test_pairing.jl
+++ b/GrothCurves/test/test_pairing.jl
@@ -174,6 +174,9 @@ using GrothAlgebra
         @test GrothCurves.cyclotomic_square(m) == square(m)
         @test GrothCurves.cyclotomic_exp(m, 11) == m^11
         @test exp_by_u(m) == m^GrothCurves.BN254_U
+        @test cyclotomic_exp_by_u(m) == exp_by_u(m)
+        @test cyclotomic_exp_by_u(cyclotomic_exp_by_u(m)) ==
+              GrothCurves.cyclotomic_exp(m, GrothCurves.BN254_U^2)
     end
 
     @testset "Pairing Consistency" begin

--- a/README.md
+++ b/README.md
@@ -65,8 +65,13 @@ The project has moved well beyond a minimal Groth16 demo.
 - Groth16 setup/proving now use an explicit G2 subgroup GLV helper for
   construction-owned key points, while generic G2 scalar multiplication remains
   the safe path for arbitrary verifier input.
+- Final exponentiation now uses an explicit cyclotomic `u` exponent path after
+  the easy part has placed the Miller-loop output in the cyclotomic subgroup.
+  The focused pairing benchmark moved final exponentiation from `1.270 ms` to
+  `0.939 ms` and single pairing from `3.135 ms` to `2.835 ms` in
+  [docs/src/assets/final_exp_gt_specialization_2026_05_11.json](./docs/src/assets/final_exp_gt_specialization_2026_05_11.json).
 - The active roadmap has shifted from broad backend replacement to targeted
-  specialization: limb-native inversion, final-exponentiation work,
+  specialization: limb-native inversion, remaining extension-field hot paths,
   prover-shaped MSM tuning, and then a fresh prover re-baseline.
 
 See [ROADMAP.md](./ROADMAP.md) for the staged backend history and remaining
@@ -168,7 +173,10 @@ Refreshed local arkworks primitive comparison
 | Single pairing | `2.960 ms` | `0.415 ms` | arkworks `7.14x` faster |
 
 These are primitive-level measurements, not end-to-end Groth16 prover
-comparisons.
+comparisons. A later same-machine local pairing microbenchmark after GT
+specialization measured single pairing at `2.835 ms`; the arkworks table above
+is kept as the preserved external-comparison artifact rather than rewritten
+across benchmark runs.
 
 Latest tracked `prove_full` prover fixture summary
 (`2026-05-11_195230`, limb-native GLV focused profile):

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -448,6 +448,31 @@ limb-native GLV H/L MSM at `9.538 ms`, and end-to-end `prove_full` at
 `26.606 ms`. The practical interpretation is a modest scalar-plumbing cleanup,
 not a new MSM algorithm.
 
+## Final Exponentiation / GT Snapshot (2026-05-11)
+
+- Baseline run:
+  `artifacts/2026-05-11_212628/results/benchmark_results.json`
+- Current run:
+  `artifacts/2026-05-11_212945/results/benchmark_results.json`
+- Tracked summary:
+  `../docs/src/assets/final_exp_gt_specialization_2026_05_11.json`
+
+This run adds a cyclotomic `u` exponent helper for values already placed in the
+cyclotomic subgroup by `final_exponentiation_easy`, and it removes integer
+scalar multiplication from the cyclotomic square recombination.
+
+| Workload | Baseline | Current | Change |
+| --- | ---: | ---: | ---: |
+| Single pairing | `3.135 ms` | `2.835 ms` | `-9.57%` |
+| Final exponentiation | `1.270 ms` | `0.939 ms` | `-26.03%` |
+| Final exponentiation hard part | `1.301 ms` | `0.930 ms` | `-28.51%` |
+| Generic `exp_by_u` | `0.379 ms` | `0.385 ms` | `+1.61%` |
+| Cyclotomic `u` exponent | - | `0.243 ms` | `-36.90%` vs current generic |
+
+The generic `exp_by_u(::Fp12Element)` remains available for arbitrary Fp12
+values; the optimized helper is only used in the GT-shaped hard
+final-exponentiation path.
+
 Generate a full report (run -> plot -> compare) for latest run:
 
 ```

--- a/benchmarks/plot.jl
+++ b/benchmarks/plot.jl
@@ -255,7 +255,7 @@ function main()
         ["pairing", "miller_loop", "final_exponentiation"],
         "Pairing micro-operations", "pairing_ops.png")
     plot_single_ops(res, out_dir, :pairing_substeps,
-        ["doubling_step", "addition_step", "evaluate_line", "frobenius_p1", "frobenius_p2", "frobenius_p3", "final_exponentiation_easy", "exp_by_u", "final_exponentiation_hard"],
+        ["doubling_step", "addition_step", "evaluate_line", "frobenius_p1", "frobenius_p2", "frobenius_p3", "final_exponentiation_easy", "exp_by_u", "cyclotomic_exp_by_u", "final_exponentiation_hard"],
         "Pairing substeps", "pairing_substeps.png")
 
     # Groth16 end-to-end

--- a/benchmarks/run.jl
+++ b/benchmarks/run.jl
@@ -848,6 +848,7 @@ function bench_pairing_substeps(results)
     frob2 = frobenius_p2(easy_pre)
     frob3 = frobenius_p3(easy_pre)
     exp_u = exp_by_u(easy_pre)
+    cyclo_exp_u = cyclotomic_exp_by_u(easy_pre)
     hard_pre = final_exponentiation_hard(easy_pre)
 
     record_semantic!(results, :pairing_substeps, "doubling_step", Dict(
@@ -864,6 +865,7 @@ function bench_pairing_substeps(results)
     record_semantic!(results, :pairing_substeps, "frobenius_p3", serialize_bn254(frob3))
     record_semantic!(results, :pairing_substeps, "final_exponentiation_easy", serialize_bn254(easy_pre))
     record_semantic!(results, :pairing_substeps, "exp_by_u", serialize_bn254(exp_u))
+    record_semantic!(results, :pairing_substeps, "cyclotomic_exp_by_u", serialize_bn254(cyclo_exp_u))
     record_semantic!(results, :pairing_substeps, "final_exponentiation_hard", serialize_bn254(hard_pre))
 
     _ = doubling_step(T_double)
@@ -874,6 +876,7 @@ function bench_pairing_substeps(results)
     _ = frobenius_p3(easy_pre)
     _ = final_exponentiation_easy(f_pre)
     _ = exp_by_u(easy_pre)
+    _ = cyclotomic_exp_by_u(easy_pre)
     _ = final_exponentiation_hard(easy_pre)
 
     tr_double = @benchmark doubling_step($T_double) seconds = 1 samples = 10
@@ -884,6 +887,7 @@ function bench_pairing_substeps(results)
     tr_frob3 = @benchmark frobenius_p3($easy_pre) seconds = 1 samples = 10
     tr_easy = @benchmark final_exponentiation_easy($f_pre) seconds = 1 samples = 10
     tr_exp_u = @benchmark exp_by_u($easy_pre) seconds = 1 samples = 10
+    tr_cyclo_exp_u = @benchmark cyclotomic_exp_by_u($easy_pre) seconds = 1 samples = 10
     tr_hard = @benchmark final_exponentiation_hard($easy_pre) seconds = 1 samples = 10
 
     print_stats("Pairing doubling_step", tr_double)
@@ -894,6 +898,7 @@ function bench_pairing_substeps(results)
     print_stats("Pairing frobenius_p3", tr_frob3)
     print_stats("Pairing final_exp_easy", tr_easy)
     print_stats("Pairing exp_by_u", tr_exp_u)
+    print_stats("Pairing cyclotomic_exp_by_u", tr_cyclo_exp_u)
     print_stats("Pairing final_exp_hard", tr_hard)
 
     record_simple!(results, :pairing_substeps, "doubling_step", tr_double)
@@ -904,6 +909,7 @@ function bench_pairing_substeps(results)
     record_simple!(results, :pairing_substeps, "frobenius_p3", tr_frob3)
     record_simple!(results, :pairing_substeps, "final_exponentiation_easy", tr_easy)
     record_simple!(results, :pairing_substeps, "exp_by_u", tr_exp_u)
+    record_simple!(results, :pairing_substeps, "cyclotomic_exp_by_u", tr_cyclo_exp_u)
     record_simple!(results, :pairing_substeps, "final_exponentiation_hard", tr_hard)
 end
 

--- a/docs/PACKAGE_REFERENCE.md
+++ b/docs/PACKAGE_REFERENCE.md
@@ -72,10 +72,16 @@ annotated rather than discarded), and follow-ups.
 - (2026-04-01) Stage 5 rewrote `BN254Curve.jl` around shared Jacobian helpers,
   specialized `Fp2` squaring in the curve hot path, and a lower-allocation
   `batch_to_affine!` implementation for both G1 and G2.
+- (2026-05-11) Final exponentiation now uses an explicit cyclotomic
+  `u`-exponent helper in the hard part after the easy part establishes
+  cyclotomic subgroup membership. `cyclotomic_square` also avoids integer
+  scalar multiplication in its recombination. The focused benchmark moved final
+  exponentiation from `1.270 ms` to `0.939 ms`.
 
 **Follow-ups**
 - Prototype a second curve/engine (e.g., BLS12-381) to validate abstractions.
-- Investigate GT cyclotomic optimisations if benchmarks surface bottlenecks.
+- Continue GT/pairing follow-through if new profiles surface another clear
+  bottleneck.
 
 ## GrothProofs
 
@@ -166,6 +172,11 @@ annotated rather than discarded), and follow-ups.
   with tracked summary `docs/src/assets/setup_full_tuning_2026_05_11.json`.
   The `generated_24_constraints` fixture reports `setup_full` at `116.918 ms`,
   down from the `142.715 ms` pre-change baseline.
+- Latest final-exponentiation/GT artifact:
+  `benchmarks/artifacts/2026-05-11_212945`, with tracked summary
+  `docs/src/assets/final_exp_gt_specialization_2026_05_11.json`. The focused
+  pairing benchmark reports final exponentiation at `0.939 ms`, down from the
+  same-turn baseline `1.270 ms`, and single pairing at `2.835 ms`.
 
 ## Docs
 
@@ -175,8 +186,8 @@ annotated rather than discarded), and follow-ups.
 
 ## Roadmap snapshot (see `ROADMAP.md`)
 
-- Immediate: limb-native inversion, final-exponentiation specialization,
-  extension-field hot paths, and prover-shaped MSM specialization.
+- Immediate: limb-native inversion, remaining extension-field hot paths, and
+  prover-shaped MSM specialization.
 - Stretch: proof aggregation, second curve prototype, then Stage 9
   parallelism / accelerators once the single-thread backend is tighter.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -78,6 +78,11 @@ an arkworks-aligned, production-friendly Groth16 stack.
   refreshed generated fixture measured `9.538 ms` for the H/L GLV-MSM phase
   versus `12.464 ms` for generic H/L MSM in the same run, with `prove_full` at
   `26.606 ms`.
+- Final exponentiation now routes the hard part through explicit cyclotomic
+  `u`-exponentiation and optimized cyclotomic squaring after the easy part has
+  established GT membership. The focused pairing benchmark moved final
+  exponentiation from `1.270 ms` to `0.939 ms`, with single pairing at
+  `2.835 ms`.
 - `setup_full` query generation now uses BN254 G1 scalar/GLV dispatch for G1
   queries and a fixed-window G2 batch path; the generated fixture is now
   `116.918 ms`.

--- a/docs/src/assets/final_exp_gt_specialization_2026_05_11.json
+++ b/docs/src/assets/final_exp_gt_specialization_2026_05_11.json
@@ -1,0 +1,65 @@
+{
+  "summary": "Final exponentiation / GT specialization: the hard final exponentiation now uses an explicit cyclotomic u-exponent helper and routes subgroup-safe self-squares through the optimized cyclotomic square. The cyclotomic square helper was also adjusted to use field additions for doubling/tripling instead of integer scalar multiplication.",
+  "date": "2026-05-11",
+  "baseline_artifact": "benchmarks/artifacts/2026-05-11_212628/results/benchmark_results.json",
+  "current_artifact": "benchmarks/artifacts/2026-05-11_212945/results/benchmark_results.json",
+  "benchmark_profile": "custom",
+  "groups": [
+    "pairing_micro",
+    "pairing_substeps"
+  ],
+  "environment": {
+    "cpu_name": "znver5",
+    "julia_version": "1.12.6",
+    "threadpools": {
+      "default": 24,
+      "interactive": 1
+    },
+    "machine": "x86_64-linux-gnu"
+  },
+  "pairing_micro": {
+    "pairing": {
+      "baseline_median_ms": 3.135,
+      "current_median_ms": 2.835,
+      "relative_to_baseline": "-9.57%"
+    },
+    "final_exponentiation": {
+      "baseline_median_ms": 1.270,
+      "current_median_ms": 0.939,
+      "relative_to_baseline": "-26.03%"
+    },
+    "miller_loop": {
+      "baseline_median_ms": 1.834,
+      "current_median_ms": 1.894,
+      "relative_to_baseline": "+3.27%"
+    }
+  },
+  "pairing_substeps": {
+    "exp_by_u_generic": {
+      "baseline_median_ms": 0.379,
+      "current_median_ms": 0.385,
+      "relative_to_baseline": "+1.61%"
+    },
+    "cyclotomic_exp_by_u": {
+      "current_median_ms": 0.243,
+      "relative_to_current_generic_exp_by_u": "-36.90%"
+    },
+    "final_exponentiation_hard": {
+      "baseline_median_ms": 1.301,
+      "current_median_ms": 0.930,
+      "relative_to_baseline": "-28.51%"
+    }
+  },
+  "validation": [
+    "cyclotomic_square(m) == square(m) for deterministic easy-part pairing output",
+    "cyclotomic_exp_by_u(m) == exp_by_u(m)",
+    "cyclotomic_exp_by_u(cyclotomic_exp_by_u(m)) == cyclotomic_exp(m, BN254_U^2)",
+    "Pairing bilinearity tests passed",
+    "Pkg.test(\"GrothCurves\"), Pkg.test(\"GrothProofs\"), and include(\"scripts/test_all.jl\") passed"
+  ],
+  "notes": [
+    "The generic exp_by_u(a::Fp12Element) remains available and preserves arbitrary-Fp12 semantics.",
+    "The optimized cyclotomic helper is used only after final_exponentiation_easy has moved the value into the cyclotomic subgroup.",
+    "Miller-loop movement in the focused run is benchmark noise; this change only targets final exponentiation."
+  ]
+}

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -399,6 +399,36 @@ moved from `27.626 ms` to `26.606 ms` (`-3.69%`), but the safer reading is that
 limb-native decomposition trims plumbing overhead without changing the broader
 prover performance picture.
 
+## Final Exponentiation / GT Snapshot (2026-05-11)
+
+- Baseline run:
+  `artifacts/2026-05-11_212628/results/benchmark_results.json`
+- Current run:
+  `artifacts/2026-05-11_212945/results/benchmark_results.json`
+- Tracked summary:
+  `docs/src/assets/final_exp_gt_specialization_2026_05_11.json`
+
+This pass keeps the generic `exp_by_u(::Fp12Element)` available for arbitrary
+`Fp12` values, but adds an explicit `cyclotomic_exp_by_u` helper for values
+already known to be in GT/cyclotomic form. The final exponentiation hard part
+uses that helper only after `final_exponentiation_easy` has established the
+cyclotomic subgroup condition. The existing cyclotomic square formula was also
+tightened to use field additions for doubling/tripling instead of integer
+scalar multiplication.
+
+| Workload | Baseline | Current | Change |
+| --- | ---: | ---: | ---: |
+| Single pairing | `3.135 ms` | `2.835 ms` | `-9.57%` |
+| Final exponentiation | `1.270 ms` | `0.939 ms` | `-26.03%` |
+| Final exponentiation hard part | `1.301 ms` | `0.930 ms` | `-28.51%` |
+| Generic `exp_by_u` | `0.379 ms` | `0.385 ms` | `+1.61%` |
+| Cyclotomic `u` exponent | - | `0.243 ms` | `-36.90%` vs current generic |
+
+Validation compares `cyclotomic_square(m)` against generic `square(m)`,
+`cyclotomic_exp_by_u(m)` against `exp_by_u(m)`, and a second `u` exponent
+against `cyclotomic_exp(m, BN254_U^2)` for deterministic easy-part pairing
+outputs. Pairing bilinearity and Groth16 verification tests pass unchanged.
+
 ## Latest Snapshot (2025‑09‑29)
 
 ```@example


### PR DESCRIPTION
## Summary
- add an explicit cyclotomic u-exponent helper for the GT-shaped hard final exponentiation path
- tighten cyclotomic_square recombination to use field additions instead of integer scalar multiplication
- update pairing substep benchmarks and docs with the 2026-05-11_212945 artifact

## Benchmark
- final_exponentiation: 1.270 ms -> 0.939 ms
- final_exponentiation_hard: 1.301 ms -> 0.930 ms
- single pairing: 3.135 ms -> 2.835 ms

## Validation
- Pkg.test("GrothCurves")
- Pkg.test("GrothProofs")
- include("scripts/test_all.jl")
- docs/make.jl
- benchmarks/run.jl --groups=pairing_micro,pairing_substeps
- benchmarks/plot.jl 2026-05-11_212945