### PR TITLE
pairing: add prepared G2 verification path

### DIFF
--- a/GrothCurves/src/BN254MillerLoop.jl
+++ b/GrothCurves/src/BN254MillerLoop.jl
@@ -67,6 +67,18 @@ struct LineCoeffs
 end
 
 """
+    BN254G2Prepared
+
+Precomputed Miller-loop line coefficients for a fixed BN254 G2 point.
+The coefficients are independent of the G1 evaluation point, so verifier paths
+can cache them for fixed verification-key elements.
+"""
+struct BN254G2Prepared
+    lines::Vector{LineCoeffs}
+    infinity::Bool
+end
+
+"""
     doubling_step(T::G2Point) -> (G2Point, LineCoeffs)
 
 Compute the doubling step in the Miller loop.
@@ -357,7 +369,88 @@ Convenience overload that reuses the shared BN254 engine.
 """
 miller_loop(P::G1Point, Q::G2Point) = miller_loop(BN254_ENGINE, P, Q)
 
+function prepare_g2(::BN254Engine, Q::G2Point)
+    if iszero(Q)
+        return BN254G2Prepared(LineCoeffs[], true)
+    end
+
+    line_count = length(ATE_LOOP_COUNT_NAF) - 1 + count(!iszero, @view ATE_LOOP_COUNT_NAF[1:end-1]) + 2
+    lines = Vector{LineCoeffs}(undef, line_count)
+    idx = 1
+
+    T = Q
+    Q_x, Q_y = to_affine(Q)
+    neg_Q_y = -Q_y
+
+    for i in (length(ATE_LOOP_COUNT_NAF)):-1:2
+        T, line_coeffs = doubling_step(T)
+        lines[idx] = line_coeffs
+        idx += 1
+
+        bit = ATE_LOOP_COUNT_NAF[i-1]
+        if bit == 1
+            T, line_coeffs = _addition_step_mixed(T, Q_x, Q_y)
+            lines[idx] = line_coeffs
+            idx += 1
+        elseif bit == -1
+            T, line_coeffs = _addition_step_mixed(T, Q_x, neg_Q_y)
+            lines[idx] = line_coeffs
+            idx += 1
+        end
+    end
+
+    Q_pi = frobenius_g2(Q, 1)
+    Q_pi2 = frobenius_g2(Q, 2)
+
+    Q_pi_x, Q_pi_y = to_affine(Q_pi)
+    T, line_coeffs = _addition_step_mixed(T, Q_pi_x, Q_pi_y)
+    lines[idx] = line_coeffs
+    idx += 1
+
+    Q_pi2_x, Q_pi2_y = to_affine(Q_pi2)
+    _, line_coeffs = _addition_step_mixed(T, Q_pi2_x, -Q_pi2_y)
+    lines[idx] = line_coeffs
+
+    return BN254G2Prepared(lines, false)
+end
+
+prepare_g2(Q::G2Point) = prepare_g2(BN254_ENGINE, Q)
+
+function miller_loop(::BN254Engine, P::G1Point, Q_prepared::BN254G2Prepared)
+    if iszero(P) || Q_prepared.infinity
+        return one(Fp12Element)
+    end
+
+    f = one(Fp12Element)
+    P_x, P_y = to_affine(P)
+    idx = 1
+
+    for i in (length(ATE_LOOP_COUNT_NAF)):-1:2
+        if i != length(ATE_LOOP_COUNT_NAF)
+            f = square(f)
+        end
+
+        f = mul_by_line(f, Q_prepared.lines[idx], P_x, P_y)
+        idx += 1
+
+        bit = ATE_LOOP_COUNT_NAF[i-1]
+        if bit != 0
+            f = mul_by_line(f, Q_prepared.lines[idx], P_x, P_y)
+            idx += 1
+        end
+    end
+
+    f = mul_by_line(f, Q_prepared.lines[idx], P_x, P_y)
+    idx += 1
+    f = mul_by_line(f, Q_prepared.lines[idx], P_x, P_y)
+
+    return f
+end
+
+miller_loop(P::G1Point, Q_prepared::BN254G2Prepared) = miller_loop(BN254_ENGINE, P, Q_prepared)
+
 # Export functions
 export LineCoeffs, doubling_step, addition_step, evaluate_line, miller_loop
 export frobenius_g2, p_power_endomorphism
 export ATE_LOOP_COUNT_NAF
+export BN254G2Prepared, prepare_g2

--- a/GrothCurves/src/BN254Pairing.jl
+++ b/GrothCurves/src/BN254Pairing.jl
@@ -47,6 +47,15 @@ Call `optimal_ate_pairing`.
 pairing(engine::BN254Engine, P::G1Point, Q::G2Point) = optimal_ate_pairing(engine, P, Q)
 pairing(P::G1Point, Q::G2Point) = pairing(BN254_ENGINE, P, Q)
 
+function pairing(engine::BN254Engine, P::G1Point, Q_prepared::BN254G2Prepared)
+    if iszero(P) || Q_prepared.infinity
+        return one(GTElement)
+    end
+    return final_exponentiation(engine, miller_loop(engine, P, Q_prepared))
+end
+
+pairing(P::G1Point, Q_prepared::BN254G2Prepared) = pairing(BN254_ENGINE, P, Q_prepared)
+
 """
     pairing_batch(P_vec::Vector{G1Point}, Q_vec::Vector{G2Point})
 
@@ -80,7 +89,29 @@ function pairing_batch(engine::BN254Engine, P_vec::Vector{G1Point}, Q_vec::Vecto
     return final_exponentiation(engine, f)
 end
 
+function pairing_batch(engine::BN254Engine, P_vec::Vector{G1Point}, Q_vec::Vector{BN254G2Prepared})
+    if length(P_vec) != length(Q_vec)
+        throw(ArgumentError("Input vectors must have the same length"))
+    end
+
+    if isempty(P_vec)
+        return one(GTElement)
+    end
+
+    f = one(Fp12Element)
+    for (P, Q) in zip(P_vec, Q_vec)
+        if !iszero(P) && !Q.infinity
+            f = f * miller_loop(engine, P, Q)
+        end
+    end
+
+    return final_exponentiation(engine, f)
+end
+
 pairing_batch(P_vec::Vector{G1Point}, Q_vec::Vector{G2Point}) =
+    pairing_batch(BN254_ENGINE, P_vec, Q_vec)
+
+pairing_batch(P_vec::Vector{G1Point}, Q_vec::Vector{BN254G2Prepared}) =
     pairing_batch(BN254_ENGINE, P_vec, Q_vec)
 
 # Export pairing functions and engine

--- a/GrothCurves/src/GrothCurves.jl
+++ b/GrothCurves/src/GrothCurves.jl
@@ -18,6 +18,7 @@ function miller_loop end
 function final_exponentiation end
 function pairing end
 function pairing_batch end
+function prepare_g2 end
 
 # Include BN254 curve implementation
 include("BN254Fp2.jl")  # Quadratic extension Fp2/Fp
@@ -42,6 +43,7 @@ export g1_subgroup_multi_scalar_mul, g1_subgroup_multi_scalar_mul_pair
 export g2_subgroup_scalar_mul
 export x_coord, y_coord, z_coord
 export LineCoeffs, doubling_step, addition_step, evaluate_line, miller_loop, frobenius_g2
+export BN254G2Prepared, prepare_g2
 export frobenius_map, frobenius_p1, frobenius_p2, frobenius_p3
 export final_exponentiation_easy, final_exponentiation_hard
 export final_exponentiation, exp_by_u, cyclotomic_exp_by_u

--- a/GrothCurves/test/test_pairing_engine_interface.jl
+++ b/GrothCurves/test/test_pairing_engine_interface.jl
@@ -32,6 +32,16 @@ function test_pairing_engine_interface(engine::AbstractPairingEngine)
                         pairing(engine, points_g1[3], points_g2[3])
         prod_batch = pairing_batch(engine, points_g1, points_g2)
         @test prod_batch == prod_separate
+
+        # Prepared G2 pairings reuse fixed-side Miller-loop line coefficients.
+        prepared_g2 = prepare_g2(engine, Q)
+        @test pairing(engine, P, prepared_g2) == pairing(engine, P, Q)
+        @test final_exponentiation(engine, miller_loop(engine, P, prepared_g2)) ==
+              pairing(engine, P, Q)
+
+        prepared_points_g2 = prepare_g2.(Ref(engine), points_g2)
+        @test pairing_batch(engine, points_g1, prepared_points_g2) == prod_batch
+        @test pairing(engine, P, prepare_g2(engine, zero(G2Point))) == one(GTElement)
     end
 end
 

--- a/GrothProofs/src/Groth16.jl
+++ b/GrothProofs/src/Groth16.jl
@@ -331,11 +331,11 @@ export setup_full, prove_full, verify_full
 
 Cache `e(α,β)` and negated `γ`, `δ` elements for the prepared verifier path.
 """
-struct PreparedVerificationKey{E<:AbstractPairingEngine}
+struct PreparedVerificationKey{E<:AbstractPairingEngine,PG2}
     vk::VerificationKey{E}
     alpha_g1_beta_g2::GTElement
-    gamma_g2_neg::G2Point
-    delta_g2_neg::G2Point
+    gamma_g2_neg::PG2
+    delta_g2_neg::PG2
 end
 
 """
@@ -345,11 +345,15 @@ Compute cached `e(α,β)` and negated `γ`, `δ` for prepared verification.
 """
 function prepare_verifying_key(vk::VerificationKey{E}) where {E<:AbstractPairingEngine}
     engine = vk.engine
-    return PreparedVerificationKey{E}(
+    beta_g2_prepared = prepare_g2(engine, vk.beta_g2)
+    gamma_g2_neg = prepare_g2(engine, -vk.gamma_g2)
+    delta_g2_neg = prepare_g2(engine, -vk.delta_g2)
+    PG2 = typeof(gamma_g2_neg)
+    return PreparedVerificationKey{E,PG2}(
         vk,
-        pairing(engine, vk.alpha_g1, vk.beta_g2),
-        -vk.gamma_g2,
-        -vk.delta_g2,
+        pairing(engine, vk.alpha_g1, beta_g2_prepared),
+        gamma_g2_neg,
+        delta_g2_neg,
     )
 end
 
@@ -398,9 +402,10 @@ function verify_with_prepared(pvk::PreparedVerificationKey{E}, proof::Groth16Pro
 
     # Multi-pairing product, single final exponentiation
     engine = pvk.vk.engine
+    proof_b_prepared = prepare_g2(engine, proof.B)
     prod = pairing_batch(engine,
         [proof.A, prepared_inputs, proof.C],
-        [proof.B, pvk.gamma_g2_neg, pvk.delta_g2_neg],
+        [proof_b_prepared, pvk.gamma_g2_neg, pvk.delta_g2_neg],
     )
     return prod == pvk.alpha_g1_beta_g2
 end

--- a/benchmarks/plot.jl
+++ b/benchmarks/plot.jl
@@ -250,7 +250,7 @@ function main()
         "BN254 pairing: Groth.jl vs py_ecc", "py_ecc_pairing.png")
 
     # Pairing summaries
-    plot_group(res, out_dir, :pairing, "Pairing sequential vs batch", ["sequential", "batch"], "pairing.png")
+    plot_group(res, out_dir, :pairing, "Pairing sequential vs batch", ["sequential", "batch", "batch_prepared"], "pairing.png")
     plot_single_ops(res, out_dir, :pairing_single,
         ["pairing", "miller_loop", "final_exponentiation"],
         "Pairing micro-operations", "pairing_ops.png")

--- a/benchmarks/run.jl
+++ b/benchmarks/run.jl
@@ -789,11 +789,13 @@ function bench_pairing_throughput(results)
         rng = MersenneTwister(200 + N)
         p_vec = [scalar_mul(g1, rand_scalar_nonzero(rng)) for _ in 1:N]
         q_vec = [scalar_mul(g2, rand_scalar_nonzero(rng)) for _ in 1:N]
+        q_prepared_vec = prepare_g2.(Ref(ENGINE), q_vec)
         println("Batch size N = ", N)
         for (P, Q) in zip(p_vec, q_vec)
             pairing(ENGINE, P, Q)
         end
         pairing_batch(ENGINE, p_vec, q_vec)
+        pairing_batch(ENGINE, p_vec, q_prepared_vec)
         tr_seq = @benchmark begin
             acc = one(GTElement)
             @inbounds for i in eachindex($p_vec)
@@ -802,10 +804,13 @@ function bench_pairing_throughput(results)
             acc
         end seconds = 2 samples = 8
         tr_batch = @benchmark pairing_batch($ENGINE, $p_vec, $q_vec) seconds = 2 samples = 8
+        tr_batch_prepared = @benchmark pairing_batch($ENGINE, $p_vec, $q_prepared_vec) seconds = 2 samples = 8
         print_stats("Pairing sequential (N=$(N))", tr_seq)
         print_stats("Pairing batch (N=$(N))", tr_batch)
+        print_stats("Pairing batch prepared (N=$(N))", tr_batch_prepared)
         record_result!(results, :pairing, string(N), "sequential", tr_seq)
         record_result!(results, :pairing, string(N), "batch", tr_batch)
+        record_result!(results, :pairing, string(N), "batch_prepared", tr_batch_prepared)
     end
 end
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -87,6 +87,10 @@ an arkworks-aligned, production-friendly Groth16 stack.
   recomputing affine addend data in the ate loop. The focused pairing benchmark
   moved the Miller loop from `1.854 ms` to `0.827 ms`, with single pairing at
   `1.713 ms`.
+- BN254 G2 preparation now caches Miller-loop line coefficients for fixed G2
+  points. Prepared Groth16 verification moved from `6.999 ms` to `6.639 ms`,
+  and prepared pairing batch `N=16` measured `13.854 ms` versus `18.212 ms`
+  for the unprepared batch path in the same run.
 - `setup_full` query generation now uses BN254 G1 scalar/GLV dispatch for G1
   queries and a fixed-window G2 batch path; the generated fixture is now
   `116.918 ms`.


### PR DESCRIPTION
## Summary
- add BN254 prepared G2 line-coefficient storage and prepared Miller-loop/pairing paths
- route Groth16 prepared verification through cached prepared gamma/delta G2 data
- add prepared single/batch pairing interface tests
- record prepared batch pairings in the benchmark suite and plot config
- update the roadmap with the refreshed prepared verifier and prepared batch results

## Validation
- scripts/test_all.jl
- benchmarks/run.jl --groups=groth16,pairing_throughput,pairing_micro
- benchmarks/run.jl --groups=pairing_throughput

## Benchmark summary
Baseline artifact: benchmarks/artifacts/2026-05-12_122947
Post-change Groth16/pairing artifact: benchmarks/artifacts/2026-05-12_124957
Focused pairing-throughput artifact: benchmarks/artifacts/2026-05-12_125143

- Groth16 verify prepared median: 6.999 ms -> 6.639 ms
- Groth16 prepare_vk median: 2.110 ms -> 2.649 ms; this is the expected one-time cost of caching prepared G2 line tables
- Pairing batch N=4 median: 5.219 ms unprepared vs 4.276 ms prepared
- Pairing batch N=16 median: 18.212 ms unprepared vs 13.854 ms prepared